### PR TITLE
feat(release-flow): multi-module aggregator release tasks

### DIFF
--- a/MULTI_MODULE_RELEASE_FLOW.md
+++ b/MULTI_MODULE_RELEASE_FLOW.md
@@ -156,8 +156,10 @@ enumerates whatever *did* apply the plugin - just `:api` in that case.
 even when `duckasteroid-release-flow` is applied to several subprojects - there is exactly one
 `.github/workflows/release-candidate.yml` / `promote-release.yml` pair per repository, generated once,
 regardless of how many modules within it are independently releasable. The Java toolchain
-substitution they perform picks up the root project's own toolchain; if applying projects use a
-different Java version than root, the installed workflow's `setup-java` step needs to provision
-whichever versions are actually in use across all applying projects (multiple versions in one
-`actions/setup-java` step), since a single CI job now has to be able to build every releasable module,
-not just root.
+substitution they perform picks up the toolchain of whichever applying project's script wins the
+registration guard first (normally root, if root applies `duckasteroid-java`); if applying projects
+use a different Java version than that one, the installed workflow's `setup-java` step needs to
+provision whichever versions are actually in use across all applying projects (multiple versions in
+one `actions/setup-java` step), since a single CI job now has to be able to build every releasable
+module, not just the one whose toolchain got picked up. Not yet designed - a spike, same as the
+"Known limitation" above.

--- a/MULTI_MODULE_RELEASE_FLOW.md
+++ b/MULTI_MODULE_RELEASE_FLOW.md
@@ -1,0 +1,163 @@
+# Multi-module release flow
+
+This document describes how `duckasteroid-release-flow`, `installReleaseWorkflows`, and the bundled
+GitHub Actions workflows behave, whether a repository releases as a single unit or as several
+independently-versioned modules. It complements [VERSIONING.md](VERSIONING.md), which covers how a
+version number itself is computed; this document covers what happens when that computation is turned
+into actual tags, changelogs, and GitHub Releases. Addresses [issue #4](https://github.com/duckAsteroid/gradle-convention-plugin/issues/4).
+
+## The core idea
+
+Apply `duckasteroid-release-flow` to whichever projects in the build should be independently
+releasable - just the root, just a subset of subprojects, or every project. Each push to `release` or
+`main` runs one pair of root-level tasks - `tagReleaseCandidates` / `promoteReleaseCandidates` - which:
+
+1. Enumerate every project in the build that has `duckasteroid-release-flow` applied.
+2. For each one, compute its candidate version and its last-final version exactly as an ordinary build
+   would (`VersionResolver`, using that project's own `tagPrefix` and path-scoped `modulePath`).
+3. Skip any project whose candidate equals its last-final version - nothing under that project's own
+   directory had a qualifying Conventional Commit since its last release, so there's nothing to tag.
+4. For every project that *does* have a qualifying change, generate its changelog, mint and push its
+   own tag, and record `{module, tag, changelog}` in a manifest file written once at the repo root.
+
+The bundled workflow reads that manifest and creates one GitHub Release per entry. A push touching one
+module produces one release; a push touching several produces several, each versioned independently; a
+push with no qualifying commits anywhere produces none.
+
+## Single-project repositories
+
+Apply `duckasteroid-java` + `duckasteroid-release-flow` only at the root, with no subprojects also
+applying `duckasteroid-release-flow`. `tagReleaseCandidates` finds exactly one releasable project - the
+root, whose `modulePath` is empty and therefore sees every commit in the repository, not just ones
+under a particular directory (this is the same "no path restriction" behavior `VersionResolver` already
+has for the root project in ordinary builds). The manifest ends up with exactly one entry, and the
+workflow creates exactly one GitHub Release per push, same as a plain single-module repository always
+has. Nothing about running this repository as a single releasable unit requires any extra
+configuration - it's what you get by simply not applying `duckasteroid-release-flow` anywhere else.
+
+## Multi-project repositories
+
+Apply `duckasteroid-release-flow` to the root and/or to any subset of subprojects, depending on which
+ones need their own release cadence. Three shapes fall out of the same mechanism:
+
+- **Fully independent modules.** Apply `duckasteroid-release-flow` to each subproject, not the root. A
+  push that only changes `:api` produces a release for `:api` alone; `:web` is silently skipped because
+  its candidate version didn't move. Each module has its own tag prefix (`api/v1.4.0`, `web/v2.1.0`,
+  ...), its own changelog, its own GitHub Release.
+- **One global version for the whole repo.** Apply `duckasteroid-release-flow` only at the root (as in
+  the single-project case above) even though the build has subprojects - the root's unrestricted
+  `modulePath` means any commit anywhere counts towards the one shared version, and no subproject ever
+  gets tagged independently.
+- **Mixed.** Apply `duckasteroid-release-flow` at the root *and* to specific subprojects that need
+  independent versioning. Root and the opted-in subprojects are each evaluated independently and can
+  both end up in the same manifest.
+
+Worked example: root tagged `v2.0.0`, `:api` (also applying `duckasteroid-release-flow`) tagged
+`api/v1.4.0`, `:web` not independently versioned. A push to `release` containing a single `fix:` commit
+touching only `:api/` produces a manifest with **two** entries: `:api` at `api/v1.4.1-RC1` (its own
+`fix:` commit), and root at `v2.0.1-RC1` (root's `modulePath` is always empty, so it sees that same
+`api/`-scoped commit too and bumps alongside it).
+
+> **Known limitation: root's scope isn't exclusive of independently-versioned subprojects.** Because
+> root's `modulePath` is unrestricted (unchanged from how it already behaves for ordinary builds - see
+> [VERSIONING.md](VERSIONING.md)'s "Multi-module repositories" section), it sees every commit in the
+> repo, including ones under a subproject that has its *own* `duckasteroid-release-flow` application.
+> In mixed mode this means root will be tagged on essentially every push that bumps *any* opted-in
+> subproject too, not just changes outside those subprojects - "root covers everything not separately
+> versioned" is the intent, but isn't what the path-scoping mechanism actually produces today. Making
+> root's scope exclude opted-in subprojects' paths would need `modulePath` to support exclusions, not
+> just a single inclusive path - not yet designed. Until then, mixed mode is really "root releases on
+> every qualifying push regardless of which module contains it, plus independently versioned
+> subprojects also release on their own." Fully independent modules or a single global version (the
+> other two shapes above) don't have this problem, since only one thing is ever computing a version
+> for any given commit.
+
+## Skipping unaffected modules
+
+The skip decision is exactly "does `VersionResolver.resolveCandidateVersion(...)` return something
+different from `VersionResolver.lastFinalVersion(...)` for this project" - the same path-scoped commit
+analysis `VersionResolver` already performs for ordinary builds, reused rather than duplicated. No new
+include/exclude configuration is needed: a module's own directory boundary, combined with Conventional
+Commits classification, is what already determines its bump for every other build; `tagReleaseCandidates`
+just also uses it to decide *whether to act at all*.
+
+`promoteReleaseCandidates` applies the same idea in reverse: a project is skipped if there's no
+release-candidate tag reachable from `HEAD` under its own prefix, rather than the build failing
+outright the way a bare `promoteReleaseCandidate` invocation would today if it found nothing to
+promote. In a mixed release wave, not every applying project necessarily had an RC cut this cycle.
+
+## The manifest
+
+`tagReleaseCandidates` and `promoteReleaseCandidates` each write `build/release-manifest.json` at the
+repo root (overwriting whatever the other one wrote last - only one of them runs per push, matching
+`release` vs. `main`):
+
+```json
+[
+  { "module": ":api", "tag": "api/v1.4.1-RC1", "changelog": "api/build/changelog.md" },
+  { "module": ":",    "tag": "v2.1.0-RC1",      "changelog": "build/changelog.md" }
+]
+```
+
+`module` is the Gradle project path (`:` for the root), `tag` is the full tag name including prefix,
+`changelog` is the path (relative to the repo root) to that project's own generated changelog. The
+bundled workflow's "Create GitHub Release" step loops over this file - one `gh release create` per
+entry, each pointed at its own `--notes-file` - instead of inferring a single tag via
+`git describe --tags --exact-match HEAD`, which only ever worked when exactly one tag landed on a
+commit.
+
+## Registration: exactly once, regardless of application site
+
+Gradle's own `./gradlew <taskName>` task-name matching already runs a task in *every* project under
+the current directory that defines it, not just the root - this is what makes `./gradlew
+tagReleaseCandidate` (singular) work today even when `duckasteroid-release-flow` is applied only to a
+subproject and never to root: Gradle finds `:api:tagReleaseCandidate` and runs it with no root
+involvement needed at all. That mechanism is also *exactly* what causes the bug in #4: registering the
+same-named task independently in every applying project means one unqualified invocation runs all of
+them, uncoordinated, in the same build.
+
+So the new aggregator tasks can't be registered the same way the existing per-project tasks are
+(once per applying project) - doing that would just move the multiple-independent-instances problem up
+one level, with several aggregator instances each redoing the full enumerate/skip/tag/manifest-write
+cycle and racing on the same `build/release-manifest.json`. Instead, whichever project(s)
+`duckasteroid-release-flow` is applied to must register `tagReleaseCandidates` /
+`promoteReleaseCandidates` / `installReleaseWorkflows` / `checkReleaseWorkflows` on `rootProject`,
+guarded so the second (and third, ...) applying project's attempt to register them is a no-op:
+
+```groovy
+if (rootProject.tasks.findByName('tagReleaseCandidates') == null) {
+    rootProject.tasks.register('tagReleaseCandidates') { /* ... */ }
+}
+```
+
+This doesn't require `rootProject` to apply `duckasteroid-java` or `duckasteroid-release-flow` itself -
+it's just a place to hang exactly one task instance, reachable the normal way (Gradle's cross-project
+name matching resolves `./gradlew tagReleaseCandidates` unqualified to that single instance, same
+mechanism as above, just now guaranteed to only ever be one). Applying `duckasteroid-release-flow` to
+only `:api` and never to root still produces a working `tagReleaseCandidates` on root, which then
+enumerates whatever *did* apply the plugin - just `:api` in that case.
+
+## Task reference
+
+| Task                          | Scope                          | Purpose                                                                                          |
+|--------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------|
+| `tagReleaseCandidate`           | single project                 | Unchanged - tags/pushes the next RC for *this* project only. Useful for local, single-module work. |
+| `promoteReleaseCandidate`       | single project                 | Unchanged - promotes *this* project's nearest RC to final.                                         |
+| `changelogForReleaseCandidate`  | single project                 | Unchanged - previews *this* project's RC notes without tagging anything.                           |
+| `changelogForRelease`           | single project                 | Unchanged - previews *this* project's final release notes.                                         |
+| `tagReleaseCandidates`          | registered once on `rootProject` | New. The task CI actually calls on every push to `release` - loops every applying project, skips unaffected ones, writes the manifest. |
+| `promoteReleaseCandidates`      | registered once on `rootProject` | New. The task CI actually calls on every push to `main` - loops every applying project, skips ones with no pending RC, writes the manifest. |
+| `installReleaseWorkflows`       | registered once on `rootProject` | Unchanged in behavior, but now guarded so it only ever exists once - one workflow pair per repo, regardless of how many projects apply `duckasteroid-release-flow`. |
+| `checkReleaseWorkflows`         | registered once on `rootProject` | Same scoping change as `installReleaseWorkflows`.                                                  |
+
+## Installing the workflows
+
+`installReleaseWorkflows` and `checkReleaseWorkflows` are registered exactly once, on `rootProject`,
+even when `duckasteroid-release-flow` is applied to several subprojects - there is exactly one
+`.github/workflows/release-candidate.yml` / `promote-release.yml` pair per repository, generated once,
+regardless of how many modules within it are independently releasable. The Java toolchain
+substitution they perform picks up the root project's own toolchain; if applying projects use a
+different Java version than root, the installed workflow's `setup-java` step needs to provision
+whichever versions are actually in use across all applying projects (multiple versions in one
+`actions/setup-java` step), since a single CI job now has to be able to build every releasable module,
+not just root.

--- a/MULTI_MODULE_RELEASE_FLOW.md
+++ b/MULTI_MODULE_RELEASE_FLOW.md
@@ -58,7 +58,8 @@ touching only `:api/` produces a manifest with **two** entries: `:api` at `api/v
 `fix:` commit), and root at `v2.0.1-RC1` (root's `modulePath` is always empty, so it sees that same
 `api/`-scoped commit too and bumps alongside it).
 
-> **Known limitation: root's scope isn't exclusive of independently-versioned subprojects.** Because
+> **Known limitation: root's scope isn't exclusive of independently-versioned subprojects**
+> ([issue #8](https://github.com/duckAsteroid/gradle-convention-plugin/issues/8)). Because
 > root's `modulePath` is unrestricted (unchanged from how it already behaves for ordinary builds - see
 > [VERSIONING.md](VERSIONING.md)'s "Multi-module repositories" section), it sees every commit in the
 > repo, including ones under a subproject that has its *own* `duckasteroid-release-flow` application.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -151,29 +151,36 @@ computed candidate version into an actual, pushed git tag, plus matching release
  develop/feature branches          release                          main
 ──────────────────────────► merge ──────────────────► merge ──────────────────►
   every build:                each push:                each push:
-  X.Y.Z-SNAPSHOT               changelogForReleaseCandidate  changelogForRelease
-  (feature branches:            tagReleaseCandidate           promoteReleaseCandidate
-   X.Y.Z-branch-SNAPSHOT)       → X.Y.Z-RC1, RC2, ...          → strips "-RCn"
-                                                                → X.Y.Z (final)
+  X.Y.Z-SNAPSHOT               tagReleaseCandidates          promoteReleaseCandidates
+  (feature branches:            → X.Y.Z-RC1, RC2, ...          → strips "-RCn"
+   X.Y.Z-branch-SNAPSHOT)        (per affected module)          → X.Y.Z (final, per module)
 ```
 
-- **`tagReleaseCandidate`** computes the candidate version (same computation as an ordinary build,
-  minus the `-SNAPSHOT` decoration) and mints the next `X.Y.Z-RCn` tag for it - `RC1` the first time
-  a given candidate version is tagged, `RC2`/`RC3`/... on each subsequent invocation for the *same*
-  candidate. Intended to run on every push to `release`, so merging accepted work from `develop` into
-  `release` automatically starts the RC cycle - and further commits on `release` (a fix spotted
-  during RC testing, say) automatically advance it - with no manual version bookkeeping anywhere.
-- **`promoteReleaseCandidate`** finds the nearest release-candidate tag reachable from the current
-  commit and strips its `-RCn` suffix to produce the final release tag. Intended to run on every push
-  to `main` - i.e. once an accepted RC has been merged from `release`.
-- **`changelogForReleaseCandidate`** / **`changelogForRelease`** generate the matching Markdown
-  release notes (see "Generating release notes" below) - each **must run before** its
-  tagging/promoting counterpart in the same job, since they look for the *previous* RC tag / the
+- **`tagReleaseCandidates`** (registered once on the root project regardless of where
+  `duckasteroid-release-flow` is applied; see "Release automation across multiple modules" below) finds
+  every project applying `duckasteroid-release-flow`, and for each one whose candidate version has
+  actually moved since its last final release, generates its changelog and mints the next `X.Y.Z-RCn`
+  tag for it - `RC1` the first time a given candidate version is tagged, `RC2`/`RC3`/... on each
+  subsequent invocation for the *same* candidate. Intended to run on every push to `release`, so
+  merging accepted work from `develop` into `release` automatically starts the RC cycle for whichever
+  modules it actually touched - and further commits on `release` (a fix spotted during RC testing, say)
+  automatically advance it - with no manual version bookkeeping anywhere. `tagReleaseCandidate`
+  (singular) is the same computation for a single project, still available for local/manual use.
+- **`promoteReleaseCandidates`** (also registered once on the root project) does the same for every project that has a
+  release-candidate tag reachable from the current commit, stripping its `-RCn` suffix to produce the
+  final release tag - skipping any applying project that has nothing pending this cycle. Intended to
+  run on every push to `main`, i.e. once an accepted RC has been merged from `release`.
+  `promoteReleaseCandidate` (singular) remains available for a single project.
+- **`changelogForReleaseCandidate`** / **`changelogForRelease`** generate a single project's Markdown
+  release notes (see "Generating release notes" below) for local preview; `tagReleaseCandidates` /
+  `promoteReleaseCandidates` generate each affected module's changelog internally as part of the same
+  run, before minting that module's tag, for the same reason a standalone invocation must run before
+  its tagging/promoting counterpart - the changelog generator looks for the *previous* RC tag / the
   last *final* tag reachable from HEAD, which the about-to-be-created new tag would otherwise shadow.
 
-Six tasks total - the four above, plus `installReleaseWorkflows`/`checkReleaseWorkflows` (install and
+Eight tasks total - the six above, plus `installReleaseWorkflows`/`checkReleaseWorkflows` (install and
 verify the two GitHub Actions workflows that invoke them; see "Installing the release workflows"
-below). All are plain Gradle tasks (`./gradlew tagReleaseCandidate`, etc.), runnable locally as well as
+below). All are plain Gradle tasks (`./gradlew tagReleaseCandidates`, etc.), runnable locally as well as
 from CI - release engineering doesn't hard-depend on GitHub Actions being available.
 [`.github/workflows/release-candidate.yml`](.github/workflows/release-candidate.yml) and
 [`promote-release.yml`](.github/workflows/promote-release.yml) are this repo's own **live** workflows,
@@ -310,6 +317,28 @@ A`), then a commit touching only `moduleB/` (`feat: big feature in module B`) - 
 `2.0.1-SNAPSHOT` (only sees its own `fix:` commit), `moduleB` computes `2.1.0-SNAPSHOT` (only sees its
 own `feat:` commit), and the root project (no path restriction) computes `2.1.0-SNAPSHOT` (sees both,
 highest bump wins).
+
+### Release automation across multiple modules
+
+Everything above is about how a *version number* is computed per module - it applies equally to an
+ordinary build and to `duckasteroid-release-flow`. Turning that computation into actual pushed tags and
+GitHub Releases for several independently-versioned modules in one repository is covered in full in
+[MULTI_MODULE_RELEASE_FLOW.md](MULTI_MODULE_RELEASE_FLOW.md); in short:
+
+- Apply `duckasteroid-release-flow` to whichever projects should be independently releasable - just the
+  root (one shared version for the whole repo), just a subset of subprojects (fully independent
+  modules), or both (a mix).
+- `tagReleaseCandidates` / `promoteReleaseCandidates` (registered once on the root project regardless of
+  where `duckasteroid-release-flow` is applied, see above) run once per push, loop over every applying
+  project, skip any whose candidate version hasn't moved, and write a manifest
+  (`build/release-manifest.json`) of `{module, tag, changelog}` for the ones that did - the bundled
+  workflow creates one GitHub Release per manifest entry rather than assuming exactly one tag landed on
+  the pushed commit.
+- `installReleaseWorkflows`/`checkReleaseWorkflows` are likewise registered exactly once, regardless of how
+  many projects apply `duckasteroid-release-flow` - one workflow pair per repository.
+- Root's `modulePath` is always empty (see above), so in mixed mode root is not scoped *away* from an
+  independently-versioned subproject's changes - see MULTI_MODULE_RELEASE_FLOW.md's "known limitation"
+  note for what that means in practice.
 
 ## Why JGit, not the `git` CLI
 

--- a/src/main/groovy/duckasteroid-release-flow.gradle
+++ b/src/main/groovy/duckasteroid-release-flow.gradle
@@ -1,8 +1,10 @@
+import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import io.github.duckasteroid.conventions.ChangelogExtension
 import io.github.duckasteroid.conventions.ChangelogGenerator
 import io.github.duckasteroid.conventions.ChangelogScope
 import io.github.duckasteroid.conventions.CommitAnalyzerExtension
+import io.github.duckasteroid.conventions.ReleaseManifest
 import io.github.duckasteroid.conventions.VersionResolver
 import io.github.duckasteroid.conventions.WorkflowChecker
 import io.github.duckasteroid.conventions.WorkflowInstaller
@@ -11,15 +13,21 @@ import io.github.duckasteroid.conventions.WorkflowInstaller
 // VERSIONING.md at the repo root. Apply alongside duckasteroid-java, which computes
 // project.ext.tagPrefix / project.ext.modulePath that these tasks reuse rather than recomputing.
 //
-// Six tasks total - tagReleaseCandidate/promoteReleaseCandidate are the release-time counterpart to
-// duckasteroid-java's ordinary-build version resolution (they don't just *compute* a version, they
-// actually create and push a tag for it); changelogForReleaseCandidate/changelogForRelease generate
-// the matching release notes (see below); installReleaseWorkflows/checkReleaseWorkflows (see issue
-// #2, further down) install/verify the GitHub Actions workflow files that invoke all four of the
-// above. All six are plain Gradle tasks, runnable locally as well as from CI - release engineering
-// shouldn't hard-depend on GitHub Actions being up. This repo's own .github/workflows/*.yml are a
-// human-readable reference for what installReleaseWorkflows installs (see VERSIONING.md) - this
-// repo can't apply its own plugins to itself, so they're not literally produced by that task here.
+// Eight tasks total. tagReleaseCandidate/promoteReleaseCandidate are the release-time counterpart
+// to duckasteroid-java's ordinary-build version resolution (they don't just *compute* a version,
+// they actually create and push a tag for it) for the applying project alone - handy for local,
+// single-module work. tagReleaseCandidates/promoteReleaseCandidates (plural - see below) are what
+// CI actually calls: they loop every project in the build that applies duckasteroid-release-flow,
+// so the same mechanism covers a single-module repo, several independently-versioned modules, or a
+// shared root version, without any of those shapes needing special-case configuration - see
+// MULTI_MODULE_RELEASE_FLOW.md. changelogForReleaseCandidate/changelogForRelease generate release
+// notes for the applying project alone (see below); installReleaseWorkflows/checkReleaseWorkflows
+// (see issue #2, further down) install/verify the GitHub Actions workflow files that invoke the
+// plural tasks above. All eight are plain Gradle tasks, runnable locally as well as from CI -
+// release engineering shouldn't hard-depend on GitHub Actions being up. This repo's own
+// .github/workflows/*.yml are a human-readable reference for what installReleaseWorkflows installs
+// (see VERSIONING.md) - this repo can't apply its own plugins to itself, so they're not literally
+// produced by that task here.
 //
 // tagReleaseCandidate/promoteReleaseCandidate respect release.forceVersion as the ultimate backstop,
 // same as the ordinary build version resolution in duckasteroid-java: if set, it's used verbatim, no
@@ -28,13 +36,19 @@ import io.github.duckasteroid.conventions.WorkflowInstaller
 // forgetting to check it. See
 // https://axion-release-plugin.readthedocs.io/en/latest/configuration/force_version/
 // (The changelog tasks have no forceVersion equivalent - release notes are generated from whatever
-// commits are actually there regardless of what version they're attached to.)
+// commits are actually there regardless of what version they're attached to.) The plural aggregator
+// tasks respect the same property, applying it as a literal version to every project they loop over
+// - a deliberately blunt "release everything with this exact number" manual override, not a
+// per-project one.
 //
 // Task actions below capture everything they need (tagPrefix, modulePath, projectDir, the
 // forceVersion property) as plain local values during task *configuration*, and shell out via
 // plain ProcessBuilder rather than project.exec at *execution* time (inside doLast) - accessing the
 // live Project object from a task action at execution time is unsupported under the configuration
-// cache, so nothing in a doLast block below may reference `project` directly.
+// cache, so nothing in a doLast block below may reference `project` directly. The plural aggregator
+// tasks below follow the same rule: the list of applying projects is captured as plain data (File/
+// String/Map values, never live Project references) from a gradle.projectsEvaluated callback, which
+// runs at configuration time, not from inside their own doLast blocks.
 //
 // changelogForReleaseCandidate / changelogForRelease (see the `changelog { }` extension below)
 // generate release notes but don't tag anything - deliberately separate from tagReleaseCandidate/
@@ -42,7 +56,8 @@ import io.github.duckasteroid.conventions.WorkflowInstaller
 // so a CI job can generate notes, then tag, in that order (changelogForReleaseCandidate must run
 // BEFORE tagReleaseCandidate: it looks for the *previous* release-candidate tag reachable from HEAD,
 // which would incorrectly find the *new* RC tag instead if that tag already existed by the time it
-// ran).
+// ran). The plural aggregator tasks generate each project's changelog internally, in the same order,
+// as part of their own doLast - a CI job calling them doesn't need a separate changelog step first.
 
 def changelogExtension = project.extensions.create('changelog', ChangelogExtension)
 changelogExtension.rcScope.convention(ChangelogScope.SINCE_LAST_RELEASE)
@@ -123,6 +138,110 @@ tasks.register('changelogForRelease') {
     }
 }
 
+// tagReleaseCandidates / promoteReleaseCandidates (see MULTI_MODULE_RELEASE_FLOW.md for the full
+// design): the plural, multi-module-aware counterparts to the two singular tasks above. Registered
+// exactly once, on rootProject, no matter which (or how many) projects apply
+// duckasteroid-release-flow - Gradle's own unqualified `./gradlew <taskName>` matching already runs
+// a same-named task in *every* project that defines it, so registering these the same way as the
+// singular tasks above (once per applying project) would mean several independent aggregator
+// instances all running from one invocation, each redoing the full enumerate/skip/tag/manifest-write
+// cycle and racing on the same build/release-manifest.json - the exact bug these tasks exist to fix,
+// just moved up one level. The `rootProject.tasks.findByName(...) == null` guard below makes the
+// first applying project's script win; every subsequent one is a no-op.
+//
+// The list of applying projects is captured once, from rootProject.gradle.projectsEvaluated
+// (fires after every project in the build has finished configuring, regardless of which one applied
+// duckasteroid-release-flow first or last) as plain data - File/String/Map values only, no live
+// Project references - and closed over by the task's doLast block. Building that list inside doLast
+// itself instead would mean touching live Project objects at task *execution* time, which is
+// unsupported under the configuration cache (see the file-level comment above).
+if (rootProject.tasks.findByName('tagReleaseCandidates') == null) {
+    def manifestFile = rootProject.layout.buildDirectory.file('release-manifest.json').get().asFile
+    def rootDir = rootProject.projectDir
+    def forceVersion = rootProject.findProperty('release.forceVersion')
+    def aggregator = rootProject.tasks.register('tagReleaseCandidates') {
+        group = 'release'
+        description = 'Loops every project applying duckasteroid-release-flow, tags/pushes the next ' +
+                'release-candidate (and generates its changelog) for each one with qualifying commits ' +
+                'since its last release, skips the rest, and writes build/release-manifest.json for CI ' +
+                'to turn into GitHub Releases. Registered once on the root project regardless of which ' +
+                'project(s) apply duckasteroid-release-flow - see MULTI_MODULE_RELEASE_FLOW.md.'
+    }
+    rootProject.gradle.projectsEvaluated {
+        List<Map> targets = releaseFlowTargets(rootProject)
+        aggregator.configure {
+            doLast {
+                ReleaseManifest manifest = new ReleaseManifest()
+                targets.each { target ->
+                    File projectDir = target.projectDir as File
+                    String tagPrefix = target.tagPrefix as String
+                    String modulePath = target.modulePath as String
+                    Map typeRules = target.typeRules as Map
+                    String candidate = forceVersion ?: VersionResolver.resolveCandidateVersion(
+                            projectDir, tagPrefix, modulePath, ['v'], typeRules)
+                    String lastFinal = VersionResolver.lastFinalVersion(projectDir, tagPrefix, ['v'])
+                    if (candidate == lastFinal) {
+                        println "tagReleaseCandidates: skipping ${target.module} - no qualifying commits since ${tagPrefix}${lastFinal}"
+                        return
+                    }
+                    List<String> messages = VersionResolver.commitMessagesForChangelog(
+                            projectDir, tagPrefix, modulePath, ['v'], target.rcScope as ChangelogScope)
+                    File changelogFile = target.changelogFile as File
+                    writeChangelog(changelogFile, ChangelogGenerator.generate(messages, typeRules))
+                    String tag = VersionResolver.nextReleaseCandidateTag(projectDir, tagPrefix, candidate)
+                    createAndPushTag(projectDir, tag)
+                    manifest.add(target.module as String, tag, relativePath(rootDir, changelogFile))
+                }
+                manifest.writeTo(manifestFile)
+                println "tagReleaseCandidates: wrote ${manifestFile} (${manifest.size()} ${manifest.size() == 1 ? 'entry' : 'entries'})"
+            }
+        }
+    }
+}
+
+if (rootProject.tasks.findByName('promoteReleaseCandidates') == null) {
+    def manifestFile = rootProject.layout.buildDirectory.file('release-manifest.json').get().asFile
+    def rootDir = rootProject.projectDir
+    def forceVersion = rootProject.findProperty('release.forceVersion')
+    def aggregator = rootProject.tasks.register('promoteReleaseCandidates') {
+        group = 'release'
+        description = 'Loops every project applying duckasteroid-release-flow, promotes each one\'s ' +
+                'nearest reachable release-candidate to a final release (generating its release notes ' +
+                'first), skips projects with no pending RC, and writes build/release-manifest.json for ' +
+                'CI to turn into GitHub Releases. Registered once on the root project - see ' +
+                'MULTI_MODULE_RELEASE_FLOW.md.'
+    }
+    rootProject.gradle.projectsEvaluated {
+        List<Map> targets = releaseFlowTargets(rootProject)
+        aggregator.configure {
+            doLast {
+                ReleaseManifest manifest = new ReleaseManifest()
+                targets.each { target ->
+                    File projectDir = target.projectDir as File
+                    String tagPrefix = target.tagPrefix as String
+                    String tag
+                    try {
+                        tag = forceVersion ? "${tagPrefix}${forceVersion}" : VersionResolver.promoteTag(projectDir, tagPrefix)
+                    } catch (IllegalStateException ignored) {
+                        println "promoteReleaseCandidates: skipping ${target.module} - no release-candidate tag reachable from HEAD"
+                        return
+                    }
+                    // Must run BEFORE createAndPushTag below - see the file-level comment on
+                    // changelogForRelease/changelogForReleaseCandidate ordering.
+                    List<String> messages = VersionResolver.commitMessagesForChangelog(
+                            projectDir, tagPrefix, target.modulePath as String, ['v'], ChangelogScope.SINCE_LAST_RELEASE)
+                    File changelogFile = target.changelogFile as File
+                    writeChangelog(changelogFile, ChangelogGenerator.generate(messages, target.typeRules as Map))
+                    createAndPushTag(projectDir, tag)
+                    manifest.add(target.module as String, tag, relativePath(rootDir, changelogFile))
+                }
+                manifest.writeTo(manifestFile)
+                println "promoteReleaseCandidates: wrote ${manifestFile} (${manifest.size()} ${manifest.size() == 1 ? 'entry' : 'entries'})"
+            }
+        }
+    }
+}
+
 // installReleaseWorkflows / checkReleaseWorkflows (see issue #2): install/verify a consumer's
 // release-candidate.yml/promote-release.yml GitHub Actions workflows, with staleness detection so
 // a consumer can tell whether their installed copy still matches what this plugin version would
@@ -132,85 +251,120 @@ tasks.register('changelogForRelease') {
 // deliberately NOT Gradle's expand()/GString syntax, since the workflow YAML itself contains live
 // '${{ github.token }}'-style GitHub Actions expressions that must survive untouched.
 //
+// There is exactly one workflow pair per repository, regardless of how many projects apply
+// duckasteroid-release-flow - like the plural tasks above, these are registered once on rootProject,
+// guarded the same way, so applying the plugin to several subprojects doesn't try to install the
+// same files several times over. The Java toolchain substituted into the template comes from
+// whichever project's script wins the guard (normally root, if root applies duckasteroid-java) -
+// see MULTI_MODULE_RELEASE_FLOW.md's "Installing the workflows" section for the current limitation
+// this implies if applying projects use differing toolchain versions.
+//
 // WorkflowInstaller/WorkflowChecker (plain Groovy classes, no Gradle dependency, unit-tested
 // directly) do the actual marker/hash comparison - see WorkflowMarker's doc comment for the
 // skip/overwrite rules. Resource bytes and the toolchain version are read at configuration time
 // (loadWorkflowResource() below, plus java.toolchain) and captured as plain local values, same
 // config-cache-safe pattern as the rest of this file: doLast blocks below never touch `project`.
-tasks.register('installReleaseWorkflows') {
-    group = 'release'
-    description = 'Installs the release-candidate/promote-release GitHub Actions workflows bundled with ' +
-            'this plugin into .github/workflows/, without clobbering files edited since a previous install ' +
-            '(use -Pduckasteroid.workflows.force=true to override).'
+if (rootProject.tasks.findByName('installReleaseWorkflows') == null) {
     def workflowsDir = new File(rootProject.projectDir, '.github/workflows')
     def javaVersion = project.extensions.getByType(JavaPluginExtension).toolchain.languageVersion.get().toString()
-    def force = project.hasProperty('duckasteroid.workflows.force')
+    def force = rootProject.hasProperty('duckasteroid.workflows.force')
     def pluginVersion = loadWorkflowResource('workflow-version.txt').trim()
     def templates = [
             'release-candidate.yml': loadWorkflowResource('release-candidate.yml'),
             'promote-release.yml'  : loadWorkflowResource('promote-release.yml'),
     ]
-    doLast {
-        templates.each { fileName, template ->
-            String body = template.replace('@@JAVA_VERSION@@', javaVersion)
-            File target = new File(workflowsDir, fileName)
-            WorkflowInstaller.Result result = WorkflowInstaller.install(target, pluginVersion, body, force)
-            switch (result) {
-                case WorkflowInstaller.Result.INSTALLED:
-                case WorkflowInstaller.Result.OVERWRITTEN:
-                case WorkflowInstaller.Result.FORCED:
-                    println "installReleaseWorkflows: wrote ${target} (${result})"
-                    break
-                case WorkflowInstaller.Result.UP_TO_DATE:
-                    println "installReleaseWorkflows: ${target} already up to date"
-                    break
-                case WorkflowInstaller.Result.SKIPPED_FOREIGN:
-                    logger.warn("installReleaseWorkflows: skipped ${target} - no duckasteroid marker found " +
-                            "(foreign or hand-written file); not overwriting it.")
-                    break
-                case WorkflowInstaller.Result.SKIPPED_MODIFIED:
-                    logger.warn("installReleaseWorkflows: skipped ${target} - edited since install (its body " +
-                            "no longer matches its marker hash); not overwriting it. Re-run with " +
-                            "-Pduckasteroid.workflows.force=true to discard those edits and take the new version.")
-                    break
+    rootProject.tasks.register('installReleaseWorkflows') {
+        group = 'release'
+        description = 'Installs the release-candidate/promote-release GitHub Actions workflows bundled with ' +
+                'this plugin into .github/workflows/, without clobbering files edited since a previous install ' +
+                '(use -Pduckasteroid.workflows.force=true to override). Registered once on the root project ' +
+                'regardless of which project(s) apply duckasteroid-release-flow.'
+        doLast {
+            templates.each { fileName, template ->
+                String body = template.replace('@@JAVA_VERSION@@', javaVersion)
+                File target = new File(workflowsDir, fileName)
+                WorkflowInstaller.Result result = WorkflowInstaller.install(target, pluginVersion, body, force)
+                switch (result) {
+                    case WorkflowInstaller.Result.INSTALLED:
+                    case WorkflowInstaller.Result.OVERWRITTEN:
+                    case WorkflowInstaller.Result.FORCED:
+                        println "installReleaseWorkflows: wrote ${target} (${result})"
+                        break
+                    case WorkflowInstaller.Result.UP_TO_DATE:
+                        println "installReleaseWorkflows: ${target} already up to date"
+                        break
+                    case WorkflowInstaller.Result.SKIPPED_FOREIGN:
+                        logger.warn("installReleaseWorkflows: skipped ${target} - no duckasteroid marker found " +
+                                "(foreign or hand-written file); not overwriting it.")
+                        break
+                    case WorkflowInstaller.Result.SKIPPED_MODIFIED:
+                        logger.warn("installReleaseWorkflows: skipped ${target} - edited since install (its body " +
+                                "no longer matches its marker hash); not overwriting it. Re-run with " +
+                                "-Pduckasteroid.workflows.force=true to discard those edits and take the new version.")
+                        break
+                }
             }
         }
     }
 }
 
-tasks.register('checkReleaseWorkflows') {
-    group = 'release'
-    description = 'Warns (never fails) if the installed release workflows are missing, unmarked, edited ' +
-            'since install, or older than the currently applied duckasteroid-release-flow version. Not ' +
-            'wired into build/check, so it never adds noise to an ordinary CI run.'
+if (rootProject.tasks.findByName('checkReleaseWorkflows') == null) {
     def workflowsDir = new File(rootProject.projectDir, '.github/workflows')
     def pluginVersion = loadWorkflowResource('workflow-version.txt').trim()
     def fileNames = ['release-candidate.yml', 'promote-release.yml']
-    doLast {
-        fileNames.each { fileName ->
-            File target = new File(workflowsDir, fileName)
-            WorkflowChecker.CheckResult result = WorkflowChecker.check(target, pluginVersion)
-            switch (result.status) {
-                case WorkflowChecker.Status.UP_TO_DATE:
-                    println "checkReleaseWorkflows: ${target} is up to date (${pluginVersion})"
-                    break
-                case WorkflowChecker.Status.MISSING:
-                    logger.warn("checkReleaseWorkflows: ${target} does not exist - run installReleaseWorkflows to install it.")
-                    break
-                case WorkflowChecker.Status.NOT_OURS:
-                    logger.warn("checkReleaseWorkflows: ${target} has no duckasteroid marker - it wasn't installed by installReleaseWorkflows.")
-                    break
-                case WorkflowChecker.Status.TAMPERED:
-                    logger.warn("checkReleaseWorkflows: ${target} has been edited since install (its body no " +
-                            "longer matches its marker hash from version ${result.installedVersion}).")
-                    break
-                case WorkflowChecker.Status.STALE:
-                    logger.warn("checkReleaseWorkflows: ${target} was installed from duckasteroid-release-flow " +
-                            "${result.installedVersion}, but ${pluginVersion} is currently applied - run " +
-                            "installReleaseWorkflows to update it.")
-                    break
+    rootProject.tasks.register('checkReleaseWorkflows') {
+        group = 'release'
+        description = 'Warns (never fails) if the installed release workflows are missing, unmarked, edited ' +
+                'since install, or older than the currently applied duckasteroid-release-flow version. Not ' +
+                'wired into build/check, so it never adds noise to an ordinary CI run. Registered once on the ' +
+                'root project regardless of which project(s) apply duckasteroid-release-flow.'
+        doLast {
+            fileNames.each { fileName ->
+                File target = new File(workflowsDir, fileName)
+                WorkflowChecker.CheckResult result = WorkflowChecker.check(target, pluginVersion)
+                switch (result.status) {
+                    case WorkflowChecker.Status.UP_TO_DATE:
+                        println "checkReleaseWorkflows: ${target} is up to date (${pluginVersion})"
+                        break
+                    case WorkflowChecker.Status.MISSING:
+                        logger.warn("checkReleaseWorkflows: ${target} does not exist - run installReleaseWorkflows to install it.")
+                        break
+                    case WorkflowChecker.Status.NOT_OURS:
+                        logger.warn("checkReleaseWorkflows: ${target} has no duckasteroid marker - it wasn't installed by installReleaseWorkflows.")
+                        break
+                    case WorkflowChecker.Status.TAMPERED:
+                        logger.warn("checkReleaseWorkflows: ${target} has been edited since install (its body no " +
+                                "longer matches its marker hash from version ${result.installedVersion}).")
+                        break
+                    case WorkflowChecker.Status.STALE:
+                        logger.warn("checkReleaseWorkflows: ${target} was installed from duckasteroid-release-flow " +
+                                "${result.installedVersion}, but ${pluginVersion} is currently applied - run " +
+                                "installReleaseWorkflows to update it.")
+                        break
+                }
             }
         }
+    }
+}
+
+/**
+ * Every project in root's build that has duckasteroid-release-flow applied, as plain data (File/
+ * String/Map values only, never live Project references - see the file-level comment above for why)
+ * for the plural aggregator tasks to loop over. Must be called from a configuration-time hook (e.g.
+ * rootProject.gradle.projectsEvaluated) after every project has finished applying its plugins, not
+ * from inside a task's doLast.
+ */
+static List<Map> releaseFlowTargets(Project root) {
+    return root.allprojects.findAll { it.pluginManager.hasPlugin('duckasteroid-release-flow') }.collect { Project p ->
+        [
+                module      : p.path,
+                projectDir  : p.projectDir,
+                tagPrefix   : p.ext.tagPrefix,
+                modulePath  : p.ext.modulePath,
+                typeRules   : p.extensions.getByType(CommitAnalyzerExtension).toTypeRules(),
+                rcScope     : p.extensions.getByType(ChangelogExtension).rcScope.get(),
+                changelogFile: p.layout.buildDirectory.file('changelog.md').get().asFile,
+        ]
     }
 }
 
@@ -235,6 +389,11 @@ def writeChangelog(File outputFile, String changelog) {
 def createAndPushTag(File repoDir, String tag) {
     runGit(repoDir, 'tag', '-a', tag, '-m', "Release ${tag}")
     runGit(repoDir, 'push', 'origin', tag)
+}
+
+/** file's path relative to base, with forward slashes regardless of OS - for the JSON manifest. */
+static String relativePath(File base, File file) {
+    return base.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char)
 }
 
 /**

--- a/src/main/groovy/io/github/duckasteroid/conventions/ReleaseManifest.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/ReleaseManifest.groovy
@@ -1,0 +1,70 @@
+package io.github.duckasteroid.conventions
+
+import groovy.json.JsonOutput
+
+/**
+ * The {@code build/release-manifest.json} file written by the {@code tagReleaseCandidates} /
+ * {@code promoteReleaseCandidates} aggregator tasks (duckasteroid-release-flow.gradle) - one entry
+ * per project that actually got tagged on a given run, read back by the bundled GitHub Actions
+ * workflow to turn into one {@code gh release create} per entry, instead of guessing a single tag
+ * via {@code git describe --tags --exact-match HEAD} (which only ever worked when exactly one
+ * project released per push). See "The manifest" in MULTI_MODULE_RELEASE_FLOW.md for the format.
+ *
+ * A plain class with no Gradle dependency, like {@link VersionResolver}/{@link ChangelogGenerator} -
+ * kept separate from the aggregator tasks themselves so the JSON shape is independently testable.
+ */
+class ReleaseManifest {
+
+    static class Entry {
+        final String module
+        final String tag
+        final String changelog
+
+        Entry(String module, String tag, String changelog) {
+            this.module = module
+            this.tag = tag
+            this.changelog = changelog
+        }
+
+        Map<String, String> toMap() {
+            // LinkedHashMap (Groovy map literals preserve insertion order) so the JSON key order
+            // always matches the documented example: module, tag, changelog.
+            return [module: module, tag: tag, changelog: changelog]
+        }
+    }
+
+    private final List<Entry> entries = []
+
+    /**
+     * @param module the Gradle project path, e.g. ":" for the root or ":api" for a subproject
+     * @param tag the full tag name that was just created, including its prefix
+     * @param changelog the generated changelog's path, relative to the repo root
+     */
+    void add(String module, String tag, String changelog) {
+        entries << new Entry(module, tag, changelog)
+    }
+
+    boolean isEmpty() {
+        return entries.isEmpty()
+    }
+
+    int size() {
+        return entries.size()
+    }
+
+    String toJson() {
+        // JsonOutput.prettyPrint("[]") renders as "[\n    \n]" (a blank indented line inside the
+        // brackets) rather than the compact "[]" one might expect - harmless to jq either way, but
+        // special-cased here so an empty manifest reads cleanly.
+        if (entries.isEmpty()) {
+            return '[]'
+        }
+        return JsonOutput.prettyPrint(JsonOutput.toJson(entries.collect { it.toMap() }))
+    }
+
+    /** Writes this manifest as JSON to file, creating parent directories as needed. */
+    void writeTo(File file) {
+        file.parentFile?.mkdirs()
+        file.text = toJson()
+    }
+}

--- a/src/main/resources/io/github/duckasteroid/conventions/workflows/promote-release.yml
+++ b/src/main/resources/io/github/duckasteroid/conventions/workflows/promote-release.yml
@@ -8,12 +8,16 @@
 # after upgrading the plugin to pick up template changes; if you've edited this file locally and
 # want to discard those edits in favor of the new template, add -Pduckasteroid.workflows.force=true.
 
-# Promotes an accepted release candidate to a final release on every push to `main`:
-# promoteReleaseCandidate strips the -RCn suffix off the nearest reachable RC tag (or picks up
-# release.forceVersion if set), mints the final tag, and this job then cuts the GitHub Release and
-# publishes it - all in the same job, for the same reason release-candidate.yml is self-contained
-# (a tag pushed with the default GITHUB_TOKEN doesn't trigger other workflow runs).
-name: Promote release candidate to final release
+# Promotes every project's accepted release candidate to a final release on every push to `main`:
+# promoteReleaseCandidates loops every project in the build that applies duckasteroid-release-flow,
+# strips the -RCn suffix off each one's nearest reachable RC tag (generating that project's own
+# final-release changelog first), skips projects with no RC pending, and writes
+# build/release-manifest.json - one {module, tag, changelog} entry per project actually promoted.
+# This job then turns each manifest entry into its own GitHub Release, all in the same job, for the
+# same reason release-candidate.yml is self-contained (a tag pushed with the default GITHUB_TOKEN
+# doesn't trigger other workflow runs). Works the same whether the repo releases as a single module
+# or several independently-versioned ones - see MULTI_MODULE_RELEASE_FLOW.md.
+name: Promote release candidates to final releases
 on:
   push:
     branches:
@@ -22,45 +26,45 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # needed to create the tag/GitHub Release
+      contents: write # needed to create the tag(s)/GitHub Release(s)
       packages: write # needed to publish to GitHub Packages
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full tag + commit history needed to find the RC tag to promote
+          fetch-depth: 0 # full tag + commit history needed to find the RC tag(s) to promote
+
       - uses: actions/setup-java@v4
         with:
           java-version: '@@JAVA_VERSION@@'
           distribution: 'temurin'
+
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # promoteReleaseCandidate creates an annotated tag, which needs a committer identity - the
+      # promoteReleaseCandidates creates annotated tags, which need a committer identity - the
       # runner has none configured by default.
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Must run BEFORE promoting: it looks for the last reachable *final* release tag, which the
-      # about-to-be-created final tag would otherwise shadow (HEAD would already be sitting on it).
-      - name: Generate release notes
-        run: ./gradlew changelogForRelease
+      - name: Promote release candidates to final
+        run: ./gradlew promoteReleaseCandidates
 
-      - name: Promote release candidate to final
-        run: ./gradlew promoteReleaseCandidate
-
-      - name: Determine tag
-        id: tag
-        run: echo "name=$(git describe --tags --exact-match HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
+      # One GitHub Release per build/release-manifest.json entry. An empty manifest (no project had
+      # a pending RC to promote) means the loop below simply does nothing - not an error.
+      - name: Create GitHub Releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ steps.tag.outputs.name }}" --notes-file build/changelog.md
+        run: |
+          jq -c '.[]' build/release-manifest.json | while IFS= read -r entry; do
+            tag=$(jq -r '.tag' <<< "$entry")
+            changelog=$(jq -r '.changelog' <<< "$entry")
+            gh release create "$tag" --notes-file "$changelog"
+          done
 
       - name: Publish package
         uses: gradle/gradle-build-action@v2

--- a/src/main/resources/io/github/duckasteroid/conventions/workflows/release-candidate.yml
+++ b/src/main/resources/io/github/duckasteroid/conventions/workflows/release-candidate.yml
@@ -8,15 +8,18 @@
 # after upgrading the plugin to pick up template changes; if you've edited this file locally and
 # want to discard those edits in favor of the new template, add -Pduckasteroid.workflows.force=true.
 
-# Auto-bumps the release-candidate number on every push to `release`: tagReleaseCandidate derives
-# the candidate version from conventional commits since the last final release (or picks up
-# release.forceVersion if set), mints the next -RCn tag, and this job then cuts a GitHub
-# pre-release and publishes it - all in the same job.
+# Auto-bumps the release-candidate number on every push to `release`: tagReleaseCandidates loops
+# every project in the build that applies duckasteroid-release-flow, tags/pushes the next RC (and
+# generates that project's own changelog) for each one with qualifying commits since its last
+# release, skips the rest, and writes build/release-manifest.json - one {module, tag, changelog}
+# entry per project actually released. This job then turns each manifest entry into its own GitHub
+# pre-release, all in the same job. Works the same whether the repo releases as a single module or
+# several independently-versioned ones - see MULTI_MODULE_RELEASE_FLOW.md.
 #
 # Deliberately self-contained rather than relying on the tag push to trigger a separate publish
 # workflow: a tag pushed with the default GITHUB_TOKEN does not trigger other workflow runs, so
 # chaining into one here would silently never fire.
-name: Tag and publish a release candidate
+name: Tag and publish release candidates
 on:
   push:
     branches:
@@ -25,45 +28,46 @@ jobs:
   release-candidate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # needed to create the tag/GitHub Release
+      contents: write # needed to create the tag(s)/GitHub Release(s)
       packages: write # needed to publish to GitHub Packages
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full tag + commit history needed to derive the version
+          fetch-depth: 0 # full tag + commit history needed to derive versions
+
       - uses: actions/setup-java@v4
         with:
           java-version: '@@JAVA_VERSION@@'
           distribution: 'temurin'
+
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # tagReleaseCandidate creates an annotated tag, which needs a committer identity - the
-      # runner has none configured by default.
+      # tagReleaseCandidates creates annotated tags, which need a committer identity - the runner
+      # has none configured by default.
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Must run BEFORE tagging: it looks for the *previous* RC tag reachable from HEAD, which the
-      # about-to-be-created tag would otherwise shadow.
-      - name: Generate release-candidate notes
-        run: ./gradlew changelogForReleaseCandidate
+      - name: Tag next release candidates
+        run: ./gradlew tagReleaseCandidates
 
-      - name: Tag next release candidate
-        run: ./gradlew tagReleaseCandidate
-
-      - name: Determine tag
-        id: tag
-        run: echo "name=$(git describe --tags --exact-match HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub pre-release
+      # One GitHub pre-release per build/release-manifest.json entry. An empty manifest (no project
+      # had qualifying commits since its last release) means the loop below simply does nothing -
+      # not an error.
+      - name: Create GitHub pre-releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ steps.tag.outputs.name }}" --notes-file build/changelog.md --prerelease
+        run: |
+          jq -c '.[]' build/release-manifest.json | while IFS= read -r entry; do
+            tag=$(jq -r '.tag' <<< "$entry")
+            changelog=$(jq -r '.changelog' <<< "$entry")
+            gh release create "$tag" --notes-file "$changelog" --prerelease
+          done
 
       - name: Publish package
         uses: gradle/gradle-build-action@v2

--- a/src/test/java/ReleaseFlowPluginTest.java
+++ b/src/test/java/ReleaseFlowPluginTest.java
@@ -7,16 +7,21 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 
 /**
- * Confirms duckasteroid-release-flow registers all six of its tasks (see the file-level comment in
- * duckasteroid-release-flow.gradle), including installReleaseWorkflows/checkReleaseWorkflows added
- * for issue #2 - task *actions* aren't exercised here (ProjectBuilder doesn't run doLast blocks;
- * that logic is covered directly by WorkflowInstallerTest/WorkflowCheckerTest instead), just that
- * applying the plugin wires them up correctly.
+ * Confirms duckasteroid-release-flow registers all eight of its tasks (see the file-level comment
+ * in duckasteroid-release-flow.gradle): the four original per-project tasks, plus the
+ * tagReleaseCandidates/promoteReleaseCandidates aggregators and the now-rootProject-scoped
+ * installReleaseWorkflows/checkReleaseWorkflows (see MULTI_MODULE_RELEASE_FLOW.md) - task *actions*
+ * aren't exercised here (ProjectBuilder doesn't run doLast blocks, and the aggregators' doLast
+ * wiring is deferred to a gradle.projectsEvaluated callback that never fires under ProjectBuilder
+ * anyway; that logic is covered directly by WorkflowInstallerTest/WorkflowCheckerTest/
+ * ReleaseManifestTest instead), just that applying the plugin wires them all up correctly. The
+ * project built here has no parent, so it IS its own rootProject - the same tasks container the
+ * plugin registers the four root-scoped tasks on.
  */
 public class ReleaseFlowPluginTest {
 
   @Test
-  void registersAllSixReleaseTasks() {
+  void registersAllEightReleaseTasks() {
     Project project = ProjectBuilder.builder().withName("test").build();
     project.getPluginManager().apply("duckasteroid-java");
     project.getPluginManager().apply("duckasteroid-release-flow");
@@ -27,6 +32,8 @@ public class ReleaseFlowPluginTest {
           "promoteReleaseCandidate",
           "changelogForReleaseCandidate",
           "changelogForRelease",
+          "tagReleaseCandidates",
+          "promoteReleaseCandidates",
           "installReleaseWorkflows",
           "checkReleaseWorkflows"
         }) {

--- a/src/test/java/ReleaseFlowSubprojectOnlyFunctionalTest.java
+++ b/src/test/java/ReleaseFlowSubprojectOnlyFunctionalTest.java
@@ -1,0 +1,107 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Functional (real Gradle process) coverage for issue #4's central claim: applying
+ * duckasteroid-release-flow to a single subproject - never the root - still produces a working
+ * tagReleaseCandidates on the root project, targeting exactly that subproject. ProjectBuilder-based
+ * ReleaseFlowPluginTest can't exercise this: the aggregator's doLast wiring is deferred to a
+ * gradle.projectsEvaluated callback that never fires under ProjectBuilder, and a single-project
+ * ProjectBuilder tree can't represent "applied to a subproject, not root" at all.
+ */
+public class ReleaseFlowSubprojectOnlyFunctionalTest {
+
+  @TempDir Path tempDir;
+  private File repo;
+  private File origin;
+
+  @BeforeEach
+  void initRepo() throws IOException, InterruptedException {
+    repo = tempDir.toFile();
+    origin = Files.createTempDirectory("release-flow-origin").toFile();
+    git(origin, "init", "-q", "--bare");
+
+    Files.writeString(
+        tempDir.resolve("settings.gradle"), "rootProject.name = 'multimod'\ninclude 'sub'\n");
+    // Root deliberately applies neither duckasteroid-java nor duckasteroid-release-flow.
+    Files.writeString(tempDir.resolve("build.gradle"), "");
+    Files.createDirectories(tempDir.resolve("sub"));
+    Files.writeString(
+        tempDir.resolve("sub/build.gradle"),
+        "plugins {\n    id 'duckasteroid-java'\n    id 'duckasteroid-release-flow'\n}\n");
+    Files.createDirectories(tempDir.resolve("sub/src/main/java"));
+    Files.writeString(tempDir.resolve("sub/src/main/java/.gitkeep"), "");
+
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+    git(repo, "remote", "add", "origin", origin.getAbsolutePath());
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "chore: initial commit");
+    git(repo, "push", "-q", "origin", "HEAD:refs/heads/main");
+  }
+
+  @Test
+  void aggregatorTargetsOnlyTheApplyingSubproject() throws Exception {
+    Files.writeString(tempDir.resolve("sub/src/main/java/Feature.java"), "class Feature {}\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "feat: add a feature to sub");
+
+    BuildResult result =
+        GradleRunner.create()
+            .withProjectDir(repo)
+            .withPluginClasspath()
+            .withArguments("tagReleaseCandidates", "--stacktrace")
+            .build();
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":tagReleaseCandidates").getOutcome());
+
+    File manifest = new File(repo, "build/release-manifest.json");
+    assertTrue(manifest.exists(), "manifest should be written to the root build directory");
+    assertFalse(
+        new File(repo, "sub/build/release-manifest.json").exists(),
+        "manifest must not also land in the applying subproject's own build directory");
+
+    String manifestJson = Files.readString(manifest.toPath());
+    assertTrue(manifestJson.contains("\":sub\""), "manifest should contain the :sub module");
+    assertTrue(
+        manifestJson.contains("sub/v0.1.0-RC1"), "manifest should contain sub's minted RC tag");
+
+    assertTrue(
+        new File(repo, "sub/build/changelog.md").exists(),
+        "sub's own changelog should be generated under its own build directory");
+
+    assertTrue(
+        gitOutput(repo, "tag", "-l").contains("sub/v0.1.0-RC1"),
+        "the RC tag should actually have been created");
+  }
+
+  private void git(File dir, String... args) throws IOException, InterruptedException {
+    gitOutput(dir, args);
+  }
+
+  private String gitOutput(File dir, String... args) throws IOException, InterruptedException {
+    String[] command = new String[args.length + 1];
+    command[0] = "git";
+    System.arraycopy(args, 0, command, 1, args.length);
+    Process process = new ProcessBuilder(command).directory(dir).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exit = process.waitFor();
+    if (exit != 0) {
+      throw new IOException("git " + String.join(" ", args) + " failed: " + output);
+    }
+    return output;
+  }
+}

--- a/src/test/java/ReleaseManifestTest.java
+++ b/src/test/java/ReleaseManifestTest.java
@@ -1,0 +1,57 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.duckasteroid.conventions.ReleaseManifest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises the build/release-manifest.json shape itself - see "The manifest" in
+ * MULTI_MODULE_RELEASE_FLOW.md for the format the bundled GitHub Actions workflow (jq) depends on.
+ */
+public class ReleaseManifestTest {
+
+  @Test
+  void emptyManifestSerializesToAnEmptyJsonArray() {
+    ReleaseManifest manifest = new ReleaseManifest();
+
+    assertTrue(manifest.isEmpty());
+    assertEquals("[]", manifest.toJson());
+  }
+
+  @Test
+  void entriesSerializeWithModuleTagChangelogKeysInOrder() {
+    ReleaseManifest manifest = new ReleaseManifest();
+    manifest.add(":api", "api/v1.4.1-RC1", "api/build/changelog.md");
+    manifest.add(":", "v2.1.0-RC1", "build/changelog.md");
+
+    assertEquals(2, manifest.size());
+    String json = manifest.toJson();
+    // Both entries present, in the order they were added, each with module/tag/changelog keys in
+    // that order - the workflow's `jq -c '.[]' | ... jq -r '.tag'` step depends on this shape.
+    int apiIndex = json.indexOf("\":api\"");
+    int rootIndex = json.indexOf("\":\"");
+    assertTrue(apiIndex >= 0 && rootIndex >= 0 && apiIndex < rootIndex, "expected :api entry before : entry");
+    assertTrue(json.indexOf("\"module\"") < json.indexOf("\"tag\""), "module key should come before tag key");
+    assertTrue(json.indexOf("\"tag\"") < json.indexOf("\"changelog\""), "tag key should come before changelog key");
+    assertTrue(json.contains("\"api/v1.4.1-RC1\""));
+    assertTrue(json.contains("\"api/build/changelog.md\""));
+  }
+
+  @Test
+  void writeToCreatesParentDirectoriesAndWritesJson(@TempDir Path tempDir) throws IOException {
+    ReleaseManifest manifest = new ReleaseManifest();
+    manifest.add(":", "v1.0.1-RC1", "build/changelog.md");
+
+    File target = tempDir.resolve("nested/release-manifest.json").toFile();
+    manifest.writeTo(target);
+
+    assertTrue(target.exists());
+    String written = Files.readString(target.toPath());
+    assertEquals(manifest.toJson(), written);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `tagReleaseCandidates`/`promoteReleaseCandidates`: root-level aggregator tasks, registered
  exactly once regardless of how many projects apply `duckasteroid-release-flow`, that loop every
  applying project, skip ones with no qualifying commits/no pending RC, and write
  `build/release-manifest.json` (one `{module, tag, changelog}` entry per project actually
  released) - the same mechanism now covers a single-module repo, several independently-versioned
  modules, or one shared root version, with no special-casing per shape.
- Moves `installReleaseWorkflows`/`checkReleaseWorkflows` to the same once-on-`rootProject`
  registration, so applying the plugin to multiple subprojects no longer races multiple copies of
  the same install/check logic against the same two files.
- Updates the bundled `release-candidate.yml`/`promote-release.yml` workflow templates
  (`installReleaseWorkflows` resources) to call the plural tasks and turn each manifest entry into
  its own `gh release create`, instead of inferring a single tag via
  `git describe --tags --exact-match HEAD` (which only ever worked for exactly one release per
  push).
- New `ReleaseManifest` plain class (+ test) for the manifest's JSON shape.
- Full design writeup in `MULTI_MODULE_RELEASE_FLOW.md`, referenced from `VERSIONING.md`.

Deliberately **not** included: updating this repo's own `.github/workflows/*.yml`. They're pinned
to the *published* `duckasteroid-release-flow:1.1.0` (see root `build.gradle`), which doesn't have
the plural tasks yet - switching them now would break this repo's own CI on the next push to
`release`/`main`. That update should happen once this change is published and the pin is bumped.

Also flagged, as known follow-ups (not addressed here) rather than blocking this PR:
- Root's `modulePath` isn't exclusive of independently-versioned subprojects in mixed mode - see the
  "Known limitation" callout in `MULTI_MODULE_RELEASE_FLOW.md`.
- Differing Java toolchain versions across applying projects in one CI job - not yet designed.

Fixes #4

## Test plan

- [x] `./gradlew build` - 105 tests passing, no configuration-cache problems.
- [x] `ReleaseFlowPluginTest` confirms all 8 tasks register correctly.
- [x] `ReleaseManifestTest` confirms the manifest JSON shape (empty array, key order, file writing).
- [ ] End-to-end exercise of `tagReleaseCandidates`/`promoteReleaseCandidates` against a real
      multi-module scratch repo, once this is published and a consumer can pull it in.
