### PR TITLE
fix(release-flow): exclude merge commits from version bump and changelog

### DIFF
--- a/src/main/groovy/io/github/duckasteroid/conventions/VersionResolver.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/VersionResolver.groovy
@@ -466,6 +466,11 @@ class VersionResolver {
      * PathFilterGroup combination, since that's exactly what `addPath` already does internally, and
      * doing it this way means we're relying on JGit's own tested implementation of "log -- path"
      * rather than a reimplementation of it.
+     *
+     * Merge commits (parentCount > 1) are excluded - their auto-generated "Merge branch 'develop'
+     * into release" messages don't conform to Conventional Commits, which would otherwise trigger
+     * the non-conforming-commit patch-bump fallback in {@link CommitAnalyzer} and add a meaningless
+     * line to every changelog. This mirrors `git log --no-merges`.
      */
     private static List<String> commitMessagesSince(Repository repo, ObjectId sinceCommitOrNull, String modulePath) {
         ObjectId headId = repo.resolve('HEAD')
@@ -481,7 +486,11 @@ class VersionResolver {
             logCommand = logCommand.addPath(modulePath)
         }
         List<String> messages = []
-        logCommand.call().each { RevCommit commit -> messages << commit.fullMessage }
+        logCommand.call().each { RevCommit commit ->
+            if (commit.parentCount <= 1) {
+                messages << commit.fullMessage
+            }
+        }
         return messages
     }
 }

--- a/src/test/java/VersionResolverTest.java
+++ b/src/test/java/VersionResolverTest.java
@@ -79,6 +79,26 @@ public class VersionResolverTest {
   }
 
   @Test
+  void mergeCommitsAreExcludedFromVersionBumpAndChangelog() throws Exception {
+    commit("chore: init");
+    tag("v1.0.0");
+    git("checkout", "-b", "feature");
+    commit("chore: internal note");
+    git("checkout", "-");
+    git("merge", "--no-ff", "-m", "Merge branch 'feature'", "feature");
+
+    // The auto-generated merge commit message doesn't conform to Conventional Commits. If it were
+    // counted, the non-conforming-commit fallback in CommitAnalyzer would bump this to 1.0.1 even
+    // though the only real commit ("chore: internal note") maps to no bump at all.
+    assertEquals("1.0.0", VersionResolver.resolveCandidateVersion(repo, PREFIX));
+
+    List<String> messages = VersionResolver.commitMessagesForChangelog(
+        repo, PREFIX, "", List.of(), ChangelogScope.SINCE_LAST_RELEASE);
+    assertEquals(1, messages.size());
+    assertTrue(messages.get(0).contains("internal note"));
+  }
+
+  @Test
   void buildVersionReturnsExactTagStrippedOfPrefixWhenHeadIsOnOne() throws Exception {
     commit("chore: init");
     tag("v1.0.0");


### PR DESCRIPTION
## Summary
- Merge commit messages (e.g. `Merge branch 'develop' into release`) don't conform to Conventional Commits, so they were tripping `CommitAnalyzer`'s non-conforming-commit fallback and injecting a spurious patch bump plus a meaningless changelog line — even when the real commits since the last release implied no bump at all.
- Filters merge commits (`parentCount > 1`) out at the single choke point both the version-bump and changelog algorithms share: `VersionResolver.commitMessagesSince`.

Fixes #11

## Test plan
- [x] Added `mergeCommitsAreExcludedFromVersionBumpAndChangelog` to `VersionResolverTest`, using a real `--no-ff` merge to assert the merge commit affects neither the resolved version nor the changelog.
- [x] `./gradlew test` — all 107 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8kqNquvAB6qwkGxC3a3B7