### PR TITLE
fix(release-flow): survive the configuration cache (issue #9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
     // Packages via the io.github.duckasteroid.github-packages-settings bootstrap in settings.gradle
     // - the same mechanism every other consumer of this plugin uses (see
     // adopt-duckasteroid-gradle-conventions skill / this repo's own README).
-    id 'duckasteroid-java' version '1.1.0'
-    id 'duckasteroid-release-flow' version '1.1.0'
+    id 'duckasteroid-java' version '1.2.0'
+    id 'duckasteroid-release-flow' version '1.2.0'
     // Published to the Gradle Plugin Portal (unlike the duckasteroid-* plugins above), so no
     // GitHub Packages settings bootstrap is needed for these two to resolve. 3.0.0 is required -
     // 2.1.0 had both plugins registering a project extension named 'agentDocs', which collided

--- a/src/main/groovy/duckasteroid-release-flow.gradle
+++ b/src/main/groovy/duckasteroid-release-flow.gradle
@@ -4,6 +4,7 @@ import io.github.duckasteroid.conventions.ChangelogExtension
 import io.github.duckasteroid.conventions.ChangelogGenerator
 import io.github.duckasteroid.conventions.ChangelogScope
 import io.github.duckasteroid.conventions.CommitAnalyzerExtension
+import io.github.duckasteroid.conventions.ReleaseGitOps
 import io.github.duckasteroid.conventions.ReleaseManifest
 import io.github.duckasteroid.conventions.VersionResolver
 import io.github.duckasteroid.conventions.WorkflowChecker
@@ -84,7 +85,7 @@ tasks.register('tagReleaseCandidate') {
         String candidate = forceVersion ?:
                 VersionResolver.resolveCandidateVersion(repoDir, tagPrefix, modulePath, ['v'], typeRules)
         String tag = VersionResolver.nextReleaseCandidateTag(repoDir, tagPrefix, candidate)
-        createAndPushTag(repoDir, tag)
+        ReleaseGitOps.createAndPushTag(repoDir, tag)
     }
 }
 
@@ -102,7 +103,7 @@ tasks.register('promoteReleaseCandidate') {
         // already exists, already under this module's own tagPrefix. Intended to run on every push
         // to `main` once an accepted RC has been merged there from `release`.
         String tag = forceVersion ? "${tagPrefix}${forceVersion}" : VersionResolver.promoteTag(repoDir, tagPrefix)
-        createAndPushTag(repoDir, tag)
+        ReleaseGitOps.createAndPushTag(repoDir, tag)
     }
 }
 
@@ -118,7 +119,7 @@ tasks.register('changelogForReleaseCandidate') {
     def outputFile = project.layout.buildDirectory.file('changelog.md').get().asFile
     doLast {
         List<String> messages = VersionResolver.commitMessagesForChangelog(repoDir, tagPrefix, modulePath, ['v'], rcScope)
-        writeChangelog(outputFile, ChangelogGenerator.generate(messages, typeRules))
+        ReleaseGitOps.writeChangelog(outputFile, ChangelogGenerator.generate(messages, typeRules))
     }
 }
 
@@ -134,7 +135,7 @@ tasks.register('changelogForRelease') {
     doLast {
         List<String> messages = VersionResolver.commitMessagesForChangelog(
                 repoDir, tagPrefix, modulePath, ['v'], ChangelogScope.SINCE_LAST_RELEASE)
-        writeChangelog(outputFile, ChangelogGenerator.generate(messages, typeRules))
+        ReleaseGitOps.writeChangelog(outputFile, ChangelogGenerator.generate(messages, typeRules))
     }
 }
 
@@ -187,10 +188,10 @@ if (rootProject.tasks.findByName('tagReleaseCandidates') == null) {
                     List<String> messages = VersionResolver.commitMessagesForChangelog(
                             projectDir, tagPrefix, modulePath, ['v'], target.rcScope as ChangelogScope)
                     File changelogFile = target.changelogFile as File
-                    writeChangelog(changelogFile, ChangelogGenerator.generate(messages, typeRules))
+                    ReleaseGitOps.writeChangelog(changelogFile, ChangelogGenerator.generate(messages, typeRules))
                     String tag = VersionResolver.nextReleaseCandidateTag(projectDir, tagPrefix, candidate)
-                    createAndPushTag(projectDir, tag)
-                    manifest.add(target.module as String, tag, relativePath(rootDir, changelogFile))
+                    ReleaseGitOps.createAndPushTag(projectDir, tag)
+                    manifest.add(target.module as String, tag, ReleaseGitOps.relativePath(rootDir, changelogFile))
                 }
                 manifest.writeTo(manifestFile)
                 println "tagReleaseCandidates: wrote ${manifestFile} (${manifest.size()} ${manifest.size() == 1 ? 'entry' : 'entries'})"
@@ -231,9 +232,9 @@ if (rootProject.tasks.findByName('promoteReleaseCandidates') == null) {
                     List<String> messages = VersionResolver.commitMessagesForChangelog(
                             projectDir, tagPrefix, target.modulePath as String, ['v'], ChangelogScope.SINCE_LAST_RELEASE)
                     File changelogFile = target.changelogFile as File
-                    writeChangelog(changelogFile, ChangelogGenerator.generate(messages, target.typeRules as Map))
-                    createAndPushTag(projectDir, tag)
-                    manifest.add(target.module as String, tag, relativePath(rootDir, changelogFile))
+                    ReleaseGitOps.writeChangelog(changelogFile, ChangelogGenerator.generate(messages, target.typeRules as Map))
+                    ReleaseGitOps.createAndPushTag(projectDir, tag)
+                    manifest.add(target.module as String, tag, ReleaseGitOps.relativePath(rootDir, changelogFile))
                 }
                 manifest.writeTo(manifestFile)
                 println "promoteReleaseCandidates: wrote ${manifestFile} (${manifest.size()} ${manifest.size() == 1 ? 'entry' : 'entries'})"
@@ -376,38 +377,4 @@ static String loadWorkflowResource(String fileName) {
         throw new IllegalStateException("Missing bundled resource: ${path}")
     }
     stream.withStream { it.getText('UTF-8') }
-}
-
-/** Writes generated changelog Markdown to outputFile, creating parent directories as needed. */
-def writeChangelog(File outputFile, String changelog) {
-    outputFile.parentFile.mkdirs()
-    outputFile.text = changelog
-    println "Changelog written to ${outputFile}"
-}
-
-/** Creates an annotated tag at HEAD and pushes it to `origin` - the only state-mutating step here. */
-def createAndPushTag(File repoDir, String tag) {
-    runGit(repoDir, 'tag', '-a', tag, '-m', "Release ${tag}")
-    runGit(repoDir, 'push', 'origin', tag)
-}
-
-/** file's path relative to base, with forward slashes regardless of OS - for the JSON manifest. */
-static String relativePath(File base, File file) {
-    return base.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char)
-}
-
-/**
- * Plain ProcessBuilder rather than project.exec (see file-level comment above for why) or
- * VersionResolver's JGit plumbing (pushing a tag needs real push credentials - the `git` CLI
- * transparently reuses whatever's already configured, both locally and via actions/checkout's
- * persisted GITHUB_TOKEN in CI, with no extra credential wiring needed here).
- */
-def runGit(File repoDir, String... args) {
-    List<String> command = ['git'] + (args as List<String>)
-    Process process = new ProcessBuilder(command).directory(repoDir).redirectErrorStream(true).start()
-    String output = process.inputStream.getText('UTF-8')
-    int exit = process.waitFor()
-    if (exit != 0) {
-        throw new RuntimeException("git ${args.join(' ')} failed (${exit}): ${output.trim()}")
-    }
 }

--- a/src/main/groovy/io/github/duckasteroid/conventions/ReleaseGitOps.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/ReleaseGitOps.groovy
@@ -1,0 +1,52 @@
+package io.github.duckasteroid.conventions
+
+/**
+ * Plain-file/process helpers for duckasteroid-release-flow.gradle's doLast blocks - changelog
+ * writing, tagging/pushing via the git CLI, and the manifest's relative-path formatting.
+ *
+ * Under the configuration cache, a doLast closure is serialized at store time and rebuilt at
+ * execution time with the task itself as owner/delegate rather than the original script instance -
+ * so an *unqualified* call to a script-level method, even a `static` one, resolves dynamically
+ * against the task's metaclass and misses (MissingMethodException). A qualified static call to an
+ * external class (`ReleaseGitOps.writeChangelog(...)`, same pattern as `VersionResolver.foo(...)`
+ * elsewhere in duckasteroid-release-flow.gradle) isn't dynamically dispatched at all - Groovy binds
+ * it directly to the class - so these live here rather than as top-level methods in the script.
+ */
+class ReleaseGitOps {
+    private ReleaseGitOps() {}
+
+    /** Writes generated changelog Markdown to outputFile, creating parent directories as needed. */
+    static void writeChangelog(File outputFile, String changelog) {
+        outputFile.parentFile.mkdirs()
+        outputFile.text = changelog
+        println "Changelog written to ${outputFile}"
+    }
+
+    /** Creates an annotated tag at HEAD and pushes it to `origin` - the only state-mutating step here. */
+    static void createAndPushTag(File repoDir, String tag) {
+        runGit(repoDir, 'tag', '-a', tag, '-m', "Release ${tag}")
+        runGit(repoDir, 'push', 'origin', tag)
+    }
+
+    /** file's path relative to base, with forward slashes regardless of OS - for the JSON manifest. */
+    static String relativePath(File base, File file) {
+        return base.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '/' as char)
+    }
+
+    /**
+     * Plain ProcessBuilder rather than project.exec (unsupported under the configuration cache from
+     * a task action at execution time) or VersionResolver's JGit plumbing (pushing a tag needs real
+     * push credentials - the `git` CLI transparently reuses whatever's already configured, both
+     * locally and via actions/checkout's persisted GITHUB_TOKEN in CI, with no extra credential
+     * wiring needed here).
+     */
+    static void runGit(File repoDir, String... args) {
+        List<String> command = ['git'] + (args as List<String>)
+        Process process = new ProcessBuilder(command).directory(repoDir).redirectErrorStream(true).start()
+        String output = process.inputStream.getText('UTF-8')
+        int exit = process.waitFor()
+        if (exit != 0) {
+            throw new RuntimeException("git ${args.join(' ')} failed (${exit}): ${output.trim()}")
+        }
+    }
+}

--- a/src/test/java/ReleaseFlowConfigCacheFunctionalTest.java
+++ b/src/test/java/ReleaseFlowConfigCacheFunctionalTest.java
@@ -1,0 +1,93 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reproduces issue #9's second problem: tagReleaseCandidates' doLast closures call the script-level
+ * instance methods writeChangelog/createAndPushTag/runGit in duckasteroid-release-flow.gradle,
+ * relying on Groovy's owner-chain resolution back to the script instance. Under the configuration
+ * cache the closure is serialized and later restored for execution with the task itself as the
+ * delegate, so the unqualified call falls through to DefaultTask's invokeMethod and misses -
+ * MissingMethodException at execution time.
+ *
+ * ReleaseFlowSubprojectOnlyFunctionalTest exercises the same aggregator without
+ * --configuration-cache, so it doesn't catch this. ReleaseFlowPluginTest only checks task
+ * registration via ProjectBuilder, which never runs doLast at all.
+ */
+public class ReleaseFlowConfigCacheFunctionalTest {
+
+  @TempDir Path tempDir;
+  private File repo;
+  private File origin;
+
+  @BeforeEach
+  void initRepo() throws IOException, InterruptedException {
+    repo = tempDir.toFile();
+    origin = Files.createTempDirectory("release-flow-cc-origin").toFile();
+    git(origin, "init", "-q", "--bare");
+
+    Files.writeString(tempDir.resolve("settings.gradle"), "rootProject.name = 'cc-fixture'\n");
+    Files.writeString(
+        tempDir.resolve("build.gradle"),
+        "plugins {\n    id 'duckasteroid-java'\n    id 'duckasteroid-release-flow'\n}\n");
+    Files.createDirectories(tempDir.resolve("src/main/java"));
+    Files.writeString(tempDir.resolve("src/main/java/.gitkeep"), "");
+
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+    git(repo, "remote", "add", "origin", origin.getAbsolutePath());
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "chore: initial commit");
+    git(repo, "push", "-q", "origin", "HEAD:refs/heads/main");
+  }
+
+  @Test
+  void tagReleaseCandidatesSurvivesConfigurationCache() throws Exception {
+    Files.writeString(tempDir.resolve("src/main/java/Feature.java"), "class Feature {}\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "feat: add a feature");
+
+    BuildResult result =
+        GradleRunner.create()
+            .withProjectDir(repo)
+            .withPluginClasspath()
+            .withArguments("tagReleaseCandidates", "--configuration-cache", "--stacktrace")
+            .build();
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":tagReleaseCandidates").getOutcome());
+    assertTrue(
+        new File(repo, "build/release-manifest.json").exists(),
+        "manifest should be written to the root build directory");
+    assertTrue(
+        gitOutput(repo, "tag", "-l").contains("v0.1.0-RC1"),
+        "the RC tag should actually have been created");
+  }
+
+  private void git(File dir, String... args) throws IOException, InterruptedException {
+    gitOutput(dir, args);
+  }
+
+  private String gitOutput(File dir, String... args) throws IOException, InterruptedException {
+    String[] command = new String[args.length + 1];
+    command[0] = "git";
+    System.arraycopy(args, 0, command, 1, args.length);
+    Process process = new ProcessBuilder(command).directory(dir).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exit = process.waitFor();
+    if (exit != 0) {
+      throw new IOException("git " + String.join(" ", args) + " failed: " + output);
+    }
+    return output;
+  }
+}

--- a/src/test/java/ReleaseFlowSubprojectConfigCacheFunctionalTest.java
+++ b/src/test/java/ReleaseFlowSubprojectConfigCacheFunctionalTest.java
@@ -1,0 +1,75 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Attempts to reproduce issue #9's first problem in a multi-module layout: duckasteroid-java
+ * applied to a subproject (not root), with root applying nothing - the shape the issue was
+ * originally found under (a two-project consumer). ReleaseFlowConfigCacheFunctionalTest already
+ * covers the single-project case under --configuration-cache and passes, so this checks whether
+ * the failure is specific to the multi-module/subproject shape rather than to
+ * ConfigCacheSafeSystemReader itself.
+ */
+public class ReleaseFlowSubprojectConfigCacheFunctionalTest {
+
+  @TempDir Path tempDir;
+  private File repo;
+  private File origin;
+
+  @BeforeEach
+  void initRepo() throws IOException, InterruptedException {
+    repo = tempDir.toFile();
+    origin = Files.createTempDirectory("release-flow-subcc-origin").toFile();
+    git(origin, "init", "-q", "--bare");
+
+    Files.writeString(
+        tempDir.resolve("settings.gradle"), "rootProject.name = 'multimod-cc'\ninclude 'sub'\n");
+    Files.writeString(tempDir.resolve("build.gradle"), "");
+    Files.createDirectories(tempDir.resolve("sub"));
+    Files.writeString(
+        tempDir.resolve("sub/build.gradle"),
+        "plugins {\n    id 'duckasteroid-java'\n    id 'duckasteroid-release-flow'\n}\n");
+    Files.createDirectories(tempDir.resolve("sub/src/main/java"));
+    Files.writeString(tempDir.resolve("sub/src/main/java/.gitkeep"), "");
+
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+    git(repo, "remote", "add", "origin", "https://github.com/duckAsteroid/multimod-cc-fixture.git");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "chore: initial commit");
+  }
+
+  @Test
+  void subprojectGhOwnerDerivationSurvivesConfigurationCache() {
+    BuildResult result =
+        GradleRunner.create()
+            .withProjectDir(repo)
+            .withPluginClasspath()
+            .withArguments(":sub:help", "--configuration-cache", "--stacktrace")
+            .build();
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":sub:help").getOutcome());
+  }
+
+  private void git(File dir, String... args) throws IOException, InterruptedException {
+    String[] command = new String[args.length + 1];
+    command[0] = "git";
+    System.arraycopy(args, 0, command, 1, args.length);
+    Process process = new ProcessBuilder(command).directory(dir).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exit = process.waitFor();
+    if (exit != 0) {
+      throw new IOException("git " + String.join(" ", args) + " failed: " + output);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Bumps this repo's own dogfooded `duckasteroid-java`/`duckasteroid-release-flow` pin from `1.1.0` to `1.2.0` — `1.1.0` predates the `ConfigCacheSafeSystemReader` fix from #3, and was confounding config-cache reproduction of #9 with an unrelated stale-version failure from this repo's own self-build.
- Fixes `tagReleaseCandidates`/`promoteReleaseCandidates` failing under `--configuration-cache` with `Could not find method writeChangelog() ... on task ':tagReleaseCandidates' of type org.gradle.api.DefaultTask`. `writeChangelog`/`createAndPushTag`/`runGit` were unqualified script-level calls inside `doLast` closures; under the configuration cache the closure is rebuilt at execution time with the task itself as owner/delegate, so the call dispatched dynamically against the task and missed. Making them `static` alone doesn't fix this — moved them into a new `ReleaseGitOps` class and call them as qualified static calls instead (the same pattern already used for `VersionResolver.foo(...)` elsewhere in this file), which Groovy binds at compile time rather than dispatching dynamically.
- With the `1.2.0` pin in place, re-ran the original `includeBuild` composite-build repro from #9 (multi-module consumer, real git repo, fresh daemon per run) for both `:sub:help --configuration-cache` and `tagReleaseCandidates --configuration-cache` — both problems described in #9 are now confirmed fixed; #9's first problem (`ConfigCacheSafeSystemReader` not taking effect) turned out to already be fixed by #3, with the original report confounded by testing against the stale `1.1.0` pin.

Closes #9.

## Test plan
- [x] `ReleaseFlowConfigCacheFunctionalTest` (new) — reproduces the `writeChangelog` `MissingMethodException` against pre-fix code, passes after the fix
- [x] `ReleaseFlowSubprojectConfigCacheFunctionalTest` (new) — multi-module ghOwner/ghBranch derivation survives `--configuration-cache`
- [x] Full `./gradlew test` suite green (109 tests)
- [x] Manual `includeBuild` composite-build repro matching #9's original report, multiple fresh-daemon runs, both `:sub:help` and `tagReleaseCandidates` under `--configuration-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012m2T6C3vjHCxVZuBZfLWKw