### PR TITLE
feat(release-flow): prune superseded release-candidate GitHub Releases

### DIFF
--- a/MULTI_MODULE_RELEASE_FLOW.md
+++ b/MULTI_MODULE_RELEASE_FLOW.md
@@ -18,7 +18,9 @@ releasable - just the root, just a subset of subprojects, or every project. Each
 3. Skip any project whose candidate equals its last-final version - nothing under that project's own
    directory had a qualifying Conventional Commit since its last release, so there's nothing to tag.
 4. For every project that *does* have a qualifying change, generate its changelog, mint and push its
-   own tag, and record `{module, tag, changelog}` in a manifest file written once at the repo root.
+   own tag, and record `{module, tag, changelog, supersededTags}` in a manifest file written once at
+   the repo root - see "The manifest" and `releaseCandidates { }` (agent-docs SKILL.md) for what
+   `supersededTags` is.
 
 The bundled workflow reads that manifest and creates one GitHub Release per entry. A push touching one
 module produces one release; a push touching several produces several, each versioned independently; a
@@ -95,17 +97,23 @@ repo root (overwriting whatever the other one wrote last - only one of them runs
 
 ```json
 [
-  { "module": ":api", "tag": "api/v1.4.1-RC1", "changelog": "api/build/changelog.md" },
-  { "module": ":",    "tag": "v2.1.0-RC1",      "changelog": "build/changelog.md" }
+  { "module": ":api", "tag": "api/v1.4.1-RC1", "changelog": "api/build/changelog.md", "supersededTags": ["api/v1.4.0-RC3"] },
+  { "module": ":",    "tag": "v2.1.0-RC1",      "changelog": "build/changelog.md",     "supersededTags": [] }
 ]
 ```
 
 `module` is the Gradle project path (`:` for the root), `tag` is the full tag name including prefix,
-`changelog` is the path (relative to the repo root) to that project's own generated changelog. The
-bundled workflow's "Create GitHub Release" step loops over this file - one `gh release create` per
+`changelog` is the path (relative to the repo root) to that project's own generated changelog,
+`supersededTags` is that project's previous release-candidate tags (this cycle, regardless of which
+candidate version they were minted under) that `tag` replaces - see the `releaseCandidates { }`
+extension in the agent-docs SKILL.md, added for
+[issue #6](https://github.com/duckAsteroid/gradle-convention-plugin/issues/6). The bundled
+workflow's "Create GitHub pre-releases" step loops over this file - one `gh release create` per
 entry, each pointed at its own `--notes-file` - instead of inferring a single tag via
 `git describe --tags --exact-match HEAD`, which only ever worked when exactly one tag landed on a
-commit.
+commit; a separate "Delete superseded release-candidate pre-releases" step then runs one
+`gh release delete` per tag in each entry's `supersededTags` (never touching the tag itself or its
+already-published package).
 
 ## Registration: exactly once, regardless of application site
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -191,6 +191,35 @@ the GitHub Release with `--notes-file`, `gradlew publish`) rather than relying o
 trigger a separate workflow, because a tag pushed with the default `GITHUB_TOKEN` doesn't trigger
 other workflow runs.
 
+## Pruning superseded release candidates
+
+Release candidates aren't permanent - only whichever one eventually gets promoted matters, and any
+earlier RC in the same cycle is either absorbed into a later one or simply abandoned. By default,
+`tagReleaseCandidates` deletes every previous RC's **GitHub Release** for that module (never the git
+tag, never the already-published package) as soon as a newer RC exists - including across a version
+change mid-cycle: if a qualifying commit raises the bump (e.g. `v1.4.0-RC3` followed by
+`v1.4.1-RC1`, a "leapfrog"), `v1.4.0-RC3`'s Release still gets superseded even though its base
+version differs from the new one. Both `tagReleaseCandidate` and `tagReleaseCandidates` also print a
+stderr warning whenever a leapfrog happens - purely informational, never blocks, same philosophy as
+the non-conforming-commit warning above.
+
+Configurable via the `releaseCandidates { }` extension:
+
+```groovy
+releaseCandidates {
+    pruneSuperseded = false   // default: true - keep every RC's GitHub Release forever instead
+    retain = 2                // default: 0 - also keep the 2 most recent RCs besides the new one,
+                               // counted by recency, not by version
+}
+```
+
+`tagReleaseCandidates` records which tags got superseded in each `build/release-manifest.json`
+entry's `supersededTags` field - see "The manifest" in `MULTI_MODULE_RELEASE_FLOW.md` - which the
+bundled workflow turns into one `gh release delete` per tag (see [issue
+#6](https://github.com/duckAsteroid/gradle-convention-plugin/issues/6)). `promoteReleaseCandidate(s)`
+never prunes anything itself: by the time a promotion happens there's only ever one live RC for that
+module, since each new RC already superseded the one before it.
+
 ## Installing the release workflows
 
 `./gradlew installReleaseWorkflows` copies the bundled `release-candidate.yml`/`promote-release.yml`

--- a/src/agent-docs/duckasteroid-release-flow/SKILL.md
+++ b/src/agent-docs/duckasteroid-release-flow/SKILL.md
@@ -42,10 +42,12 @@ apply the plugin.
   (`VersionResolver`, using that project's own `tagPrefix`/`modulePath`), skips any project whose
   candidate equals its last-final version (nothing qualifying changed under its own directory),
   and for every project that *does* qualify: generates its changelog, mints and pushes its own RC
-  tag, and records `{module, tag, changelog}` in `build/release-manifest.json` at the repo root.
-  A push touching one module produces one manifest entry; a push touching several produces
-  several, each versioned independently; a push with no qualifying commits anywhere produces an
-  empty manifest (not an error).
+  tag, and records `{module, tag, changelog, supersededTags}` in `build/release-manifest.json` at
+  the repo root. A push touching one module produces one manifest entry; a push touching several
+  produces several, each versioned independently; a push with no qualifying commits anywhere
+  produces an empty manifest (not an error). `supersededTags` — see `releaseCandidates { }` below
+  — lists this cycle's previous RC tags that the new one replaces, for the bundled workflow to
+  delete their GitHub Releases.
 - **`promoteReleaseCandidates`** — the `main`-push counterpart. Same enumeration, but promotes
   each applying project's nearest reachable RC tag to final; a project with no pending RC this
   cycle is skipped rather than failing the whole task.
@@ -116,6 +118,38 @@ changelog {
 `changelogForRelease` and `promoteReleaseCandidates` always use `SINCE_LAST_RELEASE`, regardless of
 this setting — a final release's notes should be the complete picture.
 
+## `releaseCandidates { }` extension
+
+Release candidates aren't permanent — only whichever one eventually gets promoted matters, and any
+earlier one in the same cycle is either absorbed into a later RC or simply abandoned. By default,
+`tagReleaseCandidates` deletes every previous RC's **GitHub Release** (never the git tag, never the
+already-published package — those stay put forever) as soon as a newer RC exists for that module,
+regardless of whether the candidate version itself changed along the way:
+
+```groovy
+releaseCandidates {
+    pruneSuperseded = false   // default: true — keep every RC's GitHub Release forever instead
+    retain = 2                // default: 0 — also keep the 2 most recent RCs besides the new one,
+                               // counted by recency, not by version
+}
+```
+
+- `pruneSuperseded = false` fully opts out — every RC's GitHub Release lives forever, matching the
+  plugin's pre-#6 behavior.
+- `retain` counts backward from the brand-new RC by recency, ignoring version boundaries: if a
+  qualifying commit raises the bump mid-cycle (e.g. `v1.4.0-RC3` followed by `v1.4.1-RC1` — a
+  "leapfrog"), `v1.4.0-RC3` still counts toward `retain` even though its base version differs from
+  the new one.
+- **Leapfrog warning**: whenever the freshly computed candidate's version differs from the nearest
+  current-cycle RC's version, both `tagReleaseCandidate` and `tagReleaseCandidates` print a stderr
+  warning — purely informational, never blocks, same philosophy as `CommitAnalyzer`'s
+  non-conforming-commit warning.
+- `tagReleaseCandidate` (singular) only prints the leapfrog warning — pruning is a manifest/
+  GitHub-Release concern, and the singular task has no GitHub integration point of its own.
+- `promoteReleaseCandidate(s)` never prunes anything — by the time a promotion happens there's only
+  ever one live RC for that module (each new RC already superseded the one before it), so there's
+  nothing left to clean up.
+
 ## Typical CI wiring
 
 Run `./gradlew installReleaseWorkflows` once (locally, or as a one-off task) to install the two
@@ -124,7 +158,8 @@ template changes.
 
 - On push to `release`: `tagReleaseCandidates` (generates each qualifying project's changelog and
   mints its RC tag internally, no separate changelog step needed first), then one GitHub
-  pre-release per `build/release-manifest.json` entry, then `publish`.
+  pre-release per `build/release-manifest.json` entry, then one `gh release delete` per tag in
+  each entry's `supersededTags` (see `releaseCandidates { }` above), then `publish`.
 - On push to `main`: `promoteReleaseCandidates` (same internal changelog generation), then one
   GitHub release per manifest entry, then `publish`.
 

--- a/src/main/groovy/duckasteroid-release-flow.gradle
+++ b/src/main/groovy/duckasteroid-release-flow.gradle
@@ -4,6 +4,7 @@ import io.github.duckasteroid.conventions.ChangelogExtension
 import io.github.duckasteroid.conventions.ChangelogGenerator
 import io.github.duckasteroid.conventions.ChangelogScope
 import io.github.duckasteroid.conventions.CommitAnalyzerExtension
+import io.github.duckasteroid.conventions.ReleaseCandidatesExtension
 import io.github.duckasteroid.conventions.ReleaseGitOps
 import io.github.duckasteroid.conventions.ReleaseManifest
 import io.github.duckasteroid.conventions.VersionResolver
@@ -59,9 +60,23 @@ import io.github.duckasteroid.conventions.WorkflowInstaller
 // which would incorrectly find the *new* RC tag instead if that tag already existed by the time it
 // ran). The plural aggregator tasks generate each project's changelog internally, in the same order,
 // as part of their own doLast - a CI job calling them doesn't need a separate changelog step first.
+//
+// releaseCandidates { } (see the extension below and VERSIONING.md's "Pruning superseded release
+// candidates") controls what tagReleaseCandidate(s) does once a new RC exists for a module: release
+// candidates aren't permanent, so by default every previous RC's GitHub Release (never its tag or
+// published package) is deleted, regardless of whether the candidate version itself changed
+// mid-cycle. tagReleaseCandidates records what got superseded per module in each
+// build/release-manifest.json entry's supersededTags field for the CI workflow to act on;
+// tagReleaseCandidate (singular) only prints the leapfrog warning below, since it has no GitHub
+// integration point of its own to prune anything through. promoteReleaseCandidate(s) never prunes -
+// by the time a promotion happens there's only ever one live RC for that module left to promote.
 
 def changelogExtension = project.extensions.create('changelog', ChangelogExtension)
 changelogExtension.rcScope.convention(ChangelogScope.SINCE_LAST_RELEASE)
+
+def releaseCandidatesExtension = project.extensions.create('releaseCandidates', ReleaseCandidatesExtension)
+releaseCandidatesExtension.pruneSuperseded.convention(true)
+releaseCandidatesExtension.retain.convention(0)
 
 tasks.register('tagReleaseCandidate') {
     group = 'release'
@@ -84,6 +99,19 @@ tasks.register('tagReleaseCandidate') {
         // bookkeeping required anywhere.
         String candidate = forceVersion ?:
                 VersionResolver.resolveCandidateVersion(repoDir, tagPrefix, modulePath, ['v'], typeRules)
+        // Release candidates aren't permanent - a later commit can raise the bump mid-cycle and
+        // "leapfrog" straight past whatever the most recent RC's version was (e.g. v1.4.0-RC3
+        // followed by v1.4.1-RC1). Never blocks, just flags it - see releaseCandidates { } below
+        // for what tagReleaseCandidates (the plural aggregator) does about the superseded RC's
+        // GitHub Release once this happens.
+        List<String> currentCycleTags = VersionResolver.currentCycleReleaseCandidateTags(repoDir, tagPrefix, ['v'])
+        if (!currentCycleTags.isEmpty()) {
+            String previousVersion = currentCycleTags[0].substring(tagPrefix.length()).replaceAll(/-RC\d+$/, '')
+            if (previousVersion != candidate) {
+                logger.warn("tagReleaseCandidate: candidate jumped from ${tagPrefix}${previousVersion} to " +
+                        "${tagPrefix}${candidate} - new qualifying commits raised the bump since ${currentCycleTags[0]}")
+            }
+        }
         String tag = VersionResolver.nextReleaseCandidateTag(repoDir, tagPrefix, candidate)
         ReleaseGitOps.createAndPushTag(repoDir, tag)
     }
@@ -185,13 +213,32 @@ if (rootProject.tasks.findByName('tagReleaseCandidates') == null) {
                         println "tagReleaseCandidates: skipping ${target.module} - no qualifying commits since ${tagPrefix}${lastFinal}"
                         return
                     }
+                    // Release candidates aren't permanent - a later commit can raise the bump
+                    // mid-cycle and "leapfrog" straight past whatever the most recent RC's version
+                    // was (e.g. v1.4.0-RC3 followed by v1.4.1-RC1). Never blocks, just flags it.
+                    List<String> currentCycleTags = VersionResolver.currentCycleReleaseCandidateTags(projectDir, tagPrefix, ['v'])
+                    if (!currentCycleTags.isEmpty()) {
+                        String previousVersion = currentCycleTags[0].substring(tagPrefix.length()).replaceAll(/-RC\d+$/, '')
+                        if (previousVersion != candidate) {
+                            logger.warn("tagReleaseCandidates: ${target.module} candidate jumped from ${tagPrefix}${previousVersion} " +
+                                    "to ${tagPrefix}${candidate} - new qualifying commits raised the bump since ${currentCycleTags[0]}")
+                        }
+                    }
                     List<String> messages = VersionResolver.commitMessagesForChangelog(
                             projectDir, tagPrefix, modulePath, ['v'], target.rcScope as ChangelogScope)
                     File changelogFile = target.changelogFile as File
                     ReleaseGitOps.writeChangelog(changelogFile, ChangelogGenerator.generate(messages, typeRules))
                     String tag = VersionResolver.nextReleaseCandidateTag(projectDir, tagPrefix, candidate)
                     ReleaseGitOps.createAndPushTag(projectDir, tag)
-                    manifest.add(target.module as String, tag, ReleaseGitOps.relativePath(rootDir, changelogFile))
+                    // Every current-cycle RC (regardless of which candidate version it was minted
+                    // under - see currentCycleReleaseCandidateTags) is superseded by the one just
+                    // tagged, except however many the releaseCandidates { } extension says to
+                    // retain. Only the GitHub Release gets deleted (by the CI workflow, from this
+                    // manifest entry) - the tag and its published package are left alone.
+                    boolean pruneSuperseded = target.pruneSuperseded as boolean
+                    int retain = target.retain as int
+                    List<String> supersededTags = pruneSuperseded ? currentCycleTags.drop(retain) : []
+                    manifest.add(target.module as String, tag, ReleaseGitOps.relativePath(rootDir, changelogFile), supersededTags)
                 }
                 manifest.writeTo(manifestFile)
                 println "tagReleaseCandidates: wrote ${manifestFile} (${manifest.size()} ${manifest.size() == 1 ? 'entry' : 'entries'})"
@@ -365,6 +412,8 @@ static List<Map> releaseFlowTargets(Project root) {
                 typeRules   : p.extensions.getByType(CommitAnalyzerExtension).toTypeRules(),
                 rcScope     : p.extensions.getByType(ChangelogExtension).rcScope.get(),
                 changelogFile: p.layout.buildDirectory.file('changelog.md').get().asFile,
+                pruneSuperseded: p.extensions.getByType(ReleaseCandidatesExtension).pruneSuperseded.get(),
+                retain      : p.extensions.getByType(ReleaseCandidatesExtension).retain.get(),
         ]
     }
 }

--- a/src/main/groovy/io/github/duckasteroid/conventions/ReleaseCandidatesExtension.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/ReleaseCandidatesExtension.groovy
@@ -1,0 +1,29 @@
+package io.github.duckasteroid.conventions
+
+import org.gradle.api.provider.Property
+
+/**
+ * Gradle-facing configuration for how the tagReleaseCandidates/tagReleaseCandidate tasks treat
+ * previous release candidates once a new one is minted, registered by
+ * duckasteroid-release-flow.gradle as the `releaseCandidates { }` extension. Release candidates
+ * aren't permanent artifacts - only the one that eventually gets promoted matters, and any earlier
+ * one is either absorbed into a later RC or simply abandoned - so by default every RC's GitHub
+ * Release is deleted (not the underlying git tag or published package - see
+ * {@link VersionResolver#currentCycleReleaseCandidateTags}) as soon as a newer one exists.
+ *
+ * Plain scalar Property<T>s, like {@link ChangelogExtension} - no SetProperty append-vs-replace
+ * gotcha here, `.convention(...)` works exactly as expected.
+ *
+ * <pre>
+ * releaseCandidates {
+ *     pruneSuperseded = false   // default: true - keep every RC's GitHub Release forever instead
+ *     retain = 2                // default: 0 - also keep the 2 most recent RCs besides the new one
+ * }
+ * </pre>
+ */
+abstract class ReleaseCandidatesExtension {
+
+    abstract Property<Boolean> getPruneSuperseded()
+
+    abstract Property<Integer> getRetain()
+}

--- a/src/main/groovy/io/github/duckasteroid/conventions/ReleaseManifest.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/ReleaseManifest.groovy
@@ -19,17 +19,19 @@ class ReleaseManifest {
         final String module
         final String tag
         final String changelog
+        final List<String> supersededTags
 
-        Entry(String module, String tag, String changelog) {
+        Entry(String module, String tag, String changelog, List<String> supersededTags = []) {
             this.module = module
             this.tag = tag
             this.changelog = changelog
+            this.supersededTags = supersededTags
         }
 
-        Map<String, String> toMap() {
+        Map<String, Object> toMap() {
             // LinkedHashMap (Groovy map literals preserve insertion order) so the JSON key order
-            // always matches the documented example: module, tag, changelog.
-            return [module: module, tag: tag, changelog: changelog]
+            // always matches the documented example: module, tag, changelog, supersededTags.
+            return [module: module, tag: tag, changelog: changelog, supersededTags: supersededTags]
         }
     }
 
@@ -39,9 +41,13 @@ class ReleaseManifest {
      * @param module the Gradle project path, e.g. ":" for the root or ":api" for a subproject
      * @param tag the full tag name that was just created, including its prefix
      * @param changelog the generated changelog's path, relative to the repo root
+     * @param supersededTags this cycle's previous release-candidate tags whose GitHub Release
+     *        should be deleted now that {@code tag} supersedes them (see the {@code releaseCandidates
+     *        { } } extension) - empty when pruning is disabled or nothing qualifies. The tags
+     *        themselves are never deleted, only their GitHub Release.
      */
-    void add(String module, String tag, String changelog) {
-        entries << new Entry(module, tag, changelog)
+    void add(String module, String tag, String changelog, List<String> supersededTags = []) {
+        entries << new Entry(module, tag, changelog, supersededTags)
     }
 
     boolean isEmpty() {

--- a/src/main/groovy/io/github/duckasteroid/conventions/VersionResolver.groovy
+++ b/src/main/groovy/io/github/duckasteroid/conventions/VersionResolver.groovy
@@ -167,6 +167,51 @@ class VersionResolver {
     }
 
     /**
+     * Every release-candidate tag (tagPrefix + "X.Y.Z-RCn") reachable from HEAD but not reachable
+     * from the last final release tag's commit - i.e. every RC minted during the current release
+     * cycle, regardless of which candidate version it was minted under (a later commit can raise
+     * the bump mid-cycle, "leapfrogging" an earlier RC's version - both still belong to the same
+     * cycle). Ordered nearest-to-HEAD first (most recently created). Used by
+     * duckasteroid-release-flow.gradle's tagReleaseCandidates to warn when the freshly computed
+     * candidate leapfrogs the most recent RC's version, and to decide which of this cycle's RC
+     * GitHub Releases are superseded and safe to prune.
+     */
+    static List<String> currentCycleReleaseCandidateTags(File repoDir, String tagPrefix, List<String> fallbackPrefixes = []) {
+        return withRepo(repoDir) { Repository repo ->
+            Tuple2<String, String> lookup = lastFinalVersionLookup(repo, tagPrefix, fallbackPrefixes)
+            ObjectId sinceCommit = commitForTag(repo, "${lookup.v1}${lookup.v2}")
+            Map<String, String> tagByCommit = [:]
+            allTagRefs(repo).each { Ref tagRef ->
+                String name = shortName(tagRef)
+                if (name.startsWith(tagPrefix) && RC_VERSION_SUFFIX.matcher(name.substring(tagPrefix.length())).matches()) {
+                    tagByCommit[peeledCommitId(repo, tagRef).name] = name
+                }
+            }
+            ObjectId headId = repo.resolve('HEAD')
+            if (headId == null || tagByCommit.isEmpty()) {
+                return []
+            }
+            List<String> result = []
+            RevWalk walk = new RevWalk(repo)
+            try {
+                walk.markStart(walk.parseCommit(headId))
+                if (sinceCommit != null) {
+                    walk.markUninteresting(walk.parseCommit(sinceCommit))
+                }
+                for (RevCommit commit : walk) {
+                    String tag = tagByCommit[commit.id.name]
+                    if (tag != null) {
+                        result << tag
+                    }
+                }
+            } finally {
+                walk.dispose()
+            }
+            return result
+        }
+    }
+
+    /**
      * Full commit messages to build a changelog from, for {@link ChangelogGenerator}. The "since"
      * boundary depends on scope:
      *

--- a/src/main/resources/io/github/duckasteroid/conventions/workflows/release-candidate.yml
+++ b/src/main/resources/io/github/duckasteroid/conventions/workflows/release-candidate.yml
@@ -11,9 +11,12 @@
 # Auto-bumps the release-candidate number on every push to `release`: tagReleaseCandidates loops
 # every project in the build that applies duckasteroid-release-flow, tags/pushes the next RC (and
 # generates that project's own changelog) for each one with qualifying commits since its last
-# release, skips the rest, and writes build/release-manifest.json - one {module, tag, changelog}
-# entry per project actually released. This job then turns each manifest entry into its own GitHub
-# pre-release, all in the same job. Works the same whether the repo releases as a single module or
+# release, skips the rest, and writes build/release-manifest.json - one {module, tag, changelog,
+# supersededTags} entry per project actually released. This job turns each manifest entry into its
+# own GitHub pre-release, then deletes the GitHub Release (not the tag, not the published package)
+# for every tag listed in that entry's supersededTags - release candidates aren't permanent, so by
+# default only the newest one's Release stays visible (configurable via the releaseCandidates { }
+# extension - see VERSIONING.md). Works the same whether the repo releases as a single module or
 # several independently-versioned ones - see MULTI_MODULE_RELEASE_FLOW.md.
 #
 # Deliberately self-contained rather than relying on the tag push to trigger a separate publish
@@ -67,6 +70,20 @@ jobs:
             tag=$(jq -r '.tag' <<< "$entry")
             changelog=$(jq -r '.changelog' <<< "$entry")
             gh release create "$tag" --notes-file "$changelog" --prerelease
+          done
+
+      # supersededTags lists this cycle's previous RC tags the one just created replaces (see
+      # releaseCandidates { } and issue #6) - only the GitHub Release gets deleted, the tag and its
+      # already-published package are left alone (gh release delete without --cleanup-tag never
+      # touches the tag). Tolerant of a release that's already gone (e.g. deleted manually, or a
+      # previous run failed after tagging but before creating it) - this is cleanup, not a required
+      # step, so it warns rather than failing the job.
+      - name: Delete superseded release-candidate pre-releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jq -r '.[] | .supersededTags[]' build/release-manifest.json | while IFS= read -r tag; do
+            gh release delete "$tag" --yes || echo "::warning::could not delete superseded release $tag (already gone?)"
           done
 
       - name: Publish package

--- a/src/test/java/ReleaseCandidatePruningFunctionalTest.java
+++ b/src/test/java/ReleaseCandidatePruningFunctionalTest.java
@@ -1,0 +1,136 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Functional (real Gradle process) coverage for issue #6's fix: tagReleaseCandidates records which
+ * of a cycle's previous release-candidate tags are superseded by the one it just cut, honoring the
+ * releaseCandidates { } extension's pruneSuperseded/retain settings. VersionResolverTest already
+ * covers currentCycleReleaseCandidateTags itself in isolation - this exercises the full
+ * commit -> tag -> manifest wiring across successive real RC cuts, which no other test does.
+ *
+ * All three scenarios share a deterministic version history: "feat: first feature" bumps 0.0.0 to
+ * 0.1.0 (v0.1.0-RC1); every commit after that is a "fix:", which doesn't raise the bump further, so
+ * each subsequent cut auto-increments the RC number under the same v0.1.0 candidate (v0.1.0-RC2,
+ * v0.1.0-RC3, ...) rather than leapfrogging to a new version - keeping the expected tag names fixed
+ * literals instead of needing to parse them back out of the manifest.
+ */
+public class ReleaseCandidatePruningFunctionalTest {
+
+  @TempDir Path tempDir;
+  private File repo;
+  private File origin;
+
+  @BeforeEach
+  void initRepo() throws IOException, InterruptedException {
+    repo = tempDir.toFile();
+    origin = Files.createTempDirectory("release-candidate-pruning-origin").toFile();
+    git(origin, "init", "-q", "--bare");
+
+    Files.writeString(tempDir.resolve("settings.gradle"), "rootProject.name = 'pruning-fixture'\n");
+    writeBuildGradle("");
+    Files.createDirectories(tempDir.resolve("src/main/java"));
+    Files.writeString(tempDir.resolve("src/main/java/.gitkeep"), "");
+
+    git(repo, "init", "-q");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+    git(repo, "remote", "add", "origin", origin.getAbsolutePath());
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "chore: initial commit");
+    git(repo, "push", "-q", "origin", "HEAD:refs/heads/main");
+  }
+
+  @Test
+  void defaultPruningSupersedesThePreviousRcOnTheNextCut() throws Exception {
+    commitAndCutRc("feat: first feature", "Feature1.java");
+    commitAndCutRc("fix: a follow-up fix", "Fix1.java");
+
+    String manifest = readManifest();
+    String flat = manifest.replaceAll("\\s+", "");
+    assertTrue(flat.contains("\"tag\":\"v0.1.0-RC2\""));
+    assertTrue(
+        flat.contains("\"supersededTags\":[\"v0.1.0-RC1\"]"),
+        "second RC should supersede the first: " + manifest);
+  }
+
+  @Test
+  void pruneSupersededFalseKeepsEveryPreviousRc() throws Exception {
+    writeBuildGradle("releaseCandidates {\n    pruneSuperseded = false\n}\n");
+
+    commitAndCutRc("feat: first feature", "Feature1.java");
+    commitAndCutRc("fix: a follow-up fix", "Fix1.java");
+
+    String manifest = readManifest();
+    String flat = manifest.replaceAll("\\s+", "");
+    assertTrue(flat.contains("\"tag\":\"v0.1.0-RC2\""));
+    assertTrue(
+        flat.contains("\"supersededTags\":[]"),
+        "pruning disabled - nothing should be marked superseded: " + manifest);
+  }
+
+  @Test
+  void retainKeepsTheMostRecentPreviousRcsBesidesTheNewOne() throws Exception {
+    writeBuildGradle("releaseCandidates {\n    retain = 1\n}\n");
+
+    commitAndCutRc("feat: first feature", "Feature1.java");
+    commitAndCutRc("fix: a follow-up fix", "Fix1.java");
+    commitAndCutRc("fix: another follow-up", "Fix2.java");
+
+    String manifest = readManifest();
+    String flat = manifest.replaceAll("\\s+", "");
+    assertTrue(flat.contains("\"tag\":\"v0.1.0-RC3\""));
+    assertTrue(
+        flat.contains("\"supersededTags\":[\"v0.1.0-RC1\"]"),
+        "retain=1 should keep RC2 (most recent previous) and only supersede RC1: " + manifest);
+    assertFalse(flat.contains("v0.1.0-RC2"), "RC2 should not appear as superseded: " + manifest);
+  }
+
+  private void commitAndCutRc(String message, String fileName) throws Exception {
+    Files.writeString(tempDir.resolve("src/main/java/" + fileName), "class " + fileName.replace(".java", "") + " {}\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", message);
+
+    BuildResult result =
+        GradleRunner.create()
+            .withProjectDir(repo)
+            .withPluginClasspath()
+            .withArguments("tagReleaseCandidates", "--stacktrace")
+            .build();
+    assertEquals(TaskOutcome.SUCCESS, result.task(":tagReleaseCandidates").getOutcome());
+  }
+
+  private String readManifest() throws IOException {
+    return Files.readString(new File(repo, "build/release-manifest.json").toPath());
+  }
+
+  private void writeBuildGradle(String releaseCandidatesBlock) throws IOException {
+    Files.writeString(
+        tempDir.resolve("build.gradle"),
+        "plugins {\n    id 'duckasteroid-java'\n    id 'duckasteroid-release-flow'\n}\n"
+            + releaseCandidatesBlock);
+  }
+
+  private void git(File dir, String... args) throws IOException, InterruptedException {
+    String[] command = new String[args.length + 1];
+    command[0] = "git";
+    System.arraycopy(args, 0, command, 1, args.length);
+    Process process = new ProcessBuilder(command).directory(dir).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exit = process.waitFor();
+    if (exit != 0) {
+      throw new IOException("git " + String.join(" ", args) + " failed: " + output);
+    }
+  }
+}

--- a/src/test/java/ReleaseCandidatesExtensionTest.java
+++ b/src/test/java/ReleaseCandidatesExtensionTest.java
@@ -1,0 +1,50 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.duckasteroid.conventions.ReleaseCandidatesExtension;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the releaseCandidates { } extension registered by duckasteroid-release-flow.gradle:
+ * pruneSuperseded defaults to true, retain defaults to 0, and both are plain overridable
+ * Property<T>s (no SetProperty append-vs-replace gotcha here, unlike CommitAnalyzerExtension).
+ */
+public class ReleaseCandidatesExtensionTest {
+
+  private ReleaseCandidatesExtension extensionFor(Project project) {
+    project.getPluginManager().apply("duckasteroid-java");
+    project.getPluginManager().apply("duckasteroid-release-flow");
+    return project.getExtensions().getByType(ReleaseCandidatesExtension.class);
+  }
+
+  @Test
+  void defaultsPruneEverythingExceptTheNewRc() {
+    Project project = ProjectBuilder.builder().withName("test").build();
+    ReleaseCandidatesExtension extension = extensionFor(project);
+
+    assertTrue(extension.getPruneSuperseded().get());
+    assertEquals(0, extension.getRetain().get());
+  }
+
+  @Test
+  void pruneSuperseededCanBeDisabled() {
+    Project project = ProjectBuilder.builder().withName("test").build();
+    ReleaseCandidatesExtension extension = extensionFor(project);
+
+    extension.getPruneSuperseded().set(false);
+
+    assertEquals(false, extension.getPruneSuperseded().get());
+  }
+
+  @Test
+  void retainCanBeOverridden() {
+    Project project = ProjectBuilder.builder().withName("test").build();
+    ReleaseCandidatesExtension extension = extensionFor(project);
+
+    extension.getRetain().set(2);
+
+    assertEquals(2, extension.getRetain().get());
+  }
+}

--- a/src/test/java/ReleaseManifestTest.java
+++ b/src/test/java/ReleaseManifestTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +41,29 @@ public class ReleaseManifestTest {
     assertTrue(json.indexOf("\"tag\"") < json.indexOf("\"changelog\""), "tag key should come before changelog key");
     assertTrue(json.contains("\"api/v1.4.1-RC1\""));
     assertTrue(json.contains("\"api/build/changelog.md\""));
+  }
+
+  @Test
+  void addWithoutSupersededTagsDefaultsToAnEmptyArray() {
+    ReleaseManifest manifest = new ReleaseManifest();
+    manifest.add(":", "v1.0.1-RC1", "build/changelog.md");
+
+    String json = manifest.toJson();
+    assertTrue(json.contains("\"supersededTags\""), "supersededTags key should always be present");
+    assertTrue(
+        json.indexOf("\"changelog\"") < json.indexOf("\"supersededTags\""),
+        "supersededTags key should come after changelog");
+    // An empty array, not a missing/null key - the workflow's jq loop can iterate it unconditionally.
+    assertTrue(json.replaceAll("\\s+", "").contains("\"supersededTags\":[]"));
+  }
+
+  @Test
+  void addWithSupersededTagsSerializesThemAsAnArray() {
+    ReleaseManifest manifest = new ReleaseManifest();
+    manifest.add(":", "v1.0.1-RC1", "build/changelog.md", List.of("v1.0.1-RC1-old", "v1.0.0-RC3"));
+
+    String json = manifest.toJson().replaceAll("\\s+", "");
+    assertTrue(json.contains("\"supersededTags\":[\"v1.0.1-RC1-old\",\"v1.0.0-RC3\"]"));
   }
 
   @Test

--- a/src/test/java/VersionResolverTest.java
+++ b/src/test/java/VersionResolverTest.java
@@ -282,6 +282,62 @@ public class VersionResolverTest {
     assertTrue(messages.get(0).contains("the first RC's only commit"));
   }
 
+  // ---- currentCycleReleaseCandidateTags ----
+
+  @Test
+  void currentCycleReleaseCandidateTagsEmptyWhenNoneExist() throws Exception {
+    commit("chore: init");
+    tag("v1.0.0");
+    commit("feat: add a thing");
+    assertEquals(List.of(), VersionResolver.currentCycleReleaseCandidateTags(repo, PREFIX));
+  }
+
+  @Test
+  void currentCycleReleaseCandidateTagsOrderedNearestToHeadFirst() throws Exception {
+    commit("chore: init");
+    tag("v1.0.0");
+    commit("feat: add a thing");
+    tag("v1.1.0-RC1");
+    commit("fix: a follow-up fix");
+    tag("v1.1.0-RC2");
+    commit("fix: another follow-up");
+    tag("v1.1.0-RC3");
+
+    assertEquals(
+        List.of("v1.1.0-RC3", "v1.1.0-RC2", "v1.1.0-RC1"),
+        VersionResolver.currentCycleReleaseCandidateTags(repo, PREFIX));
+  }
+
+  @Test
+  void currentCycleReleaseCandidateTagsIncludesLeapfroggedVersions() throws Exception {
+    commit("chore: init");
+    tag("v1.0.0");
+    commit("fix: a patch");
+    tag("v1.0.1-RC1");
+    commit("feat: a feature lands mid-cycle");
+    tag("v1.1.0-RC1");
+
+    // Both belong to the same cycle (since v1.0.0) even though their base versions differ - a
+    // later commit raised the bump, "leapfrogging" v1.0.1-RC1's version.
+    assertEquals(
+        List.of("v1.1.0-RC1", "v1.0.1-RC1"),
+        VersionResolver.currentCycleReleaseCandidateTags(repo, PREFIX));
+  }
+
+  @Test
+  void currentCycleReleaseCandidateTagsExcludesTagsFromAnAlreadyFinalizedCycle() throws Exception {
+    commit("chore: init");
+    tag("v1.0.0");
+    commit("feat: add a thing");
+    tag("v1.1.0-RC1");
+    tag("v1.1.0"); // promoted - v1.1.0-RC1 now belongs to a finalized, previous cycle
+    commit("fix: next cycle's first fix");
+    tag("v1.1.1-RC1");
+
+    assertEquals(
+        List.of("v1.1.1-RC1"), VersionResolver.currentCycleReleaseCandidateTags(repo, PREFIX));
+  }
+
   @Test
   void changelogRespectsFallbackPrefixesForANewModule() throws Exception {
     commit("chore: init");


### PR DESCRIPTION
## Summary
- Release candidates aren't permanent — only whichever one eventually gets promoted matters. `tagReleaseCandidates` now deletes the GitHub Release (never the git tag, never the already-published package) for every previous RC a module had this cycle, as soon as a newer RC is cut — regardless of whether the candidate version itself changed mid-cycle (a "leapfrog", e.g. `v1.4.0-RC3` followed directly by `v1.4.1-RC1`).
- New `releaseCandidates { pruneSuperseded; retain }` extension: `pruneSuperseded = false` opts out entirely (today's behavior); `retain = N` keeps the N most recent previous RCs besides the new one, counted by recency rather than by version.
- Both `tagReleaseCandidate` and `tagReleaseCandidates` print a stderr warning whenever a leapfrog happens — purely informational, never blocks, same philosophy as `CommitAnalyzer`'s non-conforming-commit warning.
- `promoteReleaseCandidate(s)` prunes nothing — by the time a promotion happens there's only ever one live RC per module, since each new RC already superseded the one before it.
- New `VersionResolver.currentCycleReleaseCandidateTags` (RC tags reachable from HEAD, not reachable from the last final release tag, ordered nearest-to-HEAD first) backs both the leapfrog check and the prune decision.
- `ReleaseManifest.Entry` gains a `supersededTags` field; the bundled `release-candidate.yml` template gained a "Delete superseded release-candidate pre-releases" step that loops it with `gh release delete "$tag" --yes` (no `--cleanup-tag`, so the tag survives) per entry, tolerant of a release that's already gone.
- Documented in `VERSIONING.md`, `MULTI_MODULE_RELEASE_FLOW.md`, and the `duckasteroid-release-flow` agent-docs `SKILL.md`.

Note: this repo's own live `.github/workflows/release-candidate.yml` is already stale relative to the bundled template (predates the multi-module aggregator work in #4/#7) — a pre-existing gap, not touched here.

Stacked on #13 (config-cache fixes) since this branch builds on top of `ReleaseGitOps` — based against `feature/config-cache-fixes` rather than `develop` for a clean diff; retarget to `develop` once #13 merges.

Closes #6.

## Test plan
- [x] `VersionResolverTest` — `currentCycleReleaseCandidateTags`: empty when none exist, ordered nearest-first, includes leapfrogged versions in the same cycle, excludes tags from an already-finalized prior cycle
- [x] `ReleaseCandidatesExtensionTest` — `pruneSuperseded`/`retain` defaults and overrides
- [x] `ReleaseManifestTest` — `supersededTags` defaults to `[]`, serializes correctly, key ordering
- [x] `ReleaseCandidatePruningFunctionalTest` (new, real Gradle process across successive RC cuts) — default pruning supersedes the previous RC, `pruneSuperseded = false` keeps everything, `retain = 1` keeps the most recent previous RC only
- [x] Full `./gradlew build` green (121 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012m2T6C3vjHCxVZuBZfLWKw